### PR TITLE
trying to fix width issue with learn page

### DIFF
--- a/app/styles/_learn.scss
+++ b/app/styles/_learn.scss
@@ -109,9 +109,12 @@
 //   padding: 0 0.5rem;
 // }
 
+main.container section {
+  padding: 1em 0;
+}
+
 //delete these after fixes are in ember-styleguide
 section {
-  padding: 1em 25em;
   h1, p {
     min-width: 100%;
   }
@@ -140,8 +143,7 @@ section {
     img {
       height: 50px;
       width: auto;
-    }  
+    }
   }
 
 }
-

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,7 +1,9 @@
 {{#es-header}}
   {{es-navbar links=links}}
 {{/es-header}}
-<main>
-{{outlet}}
+
+<main class="container">
+  {{outlet}}
 </main>
+
 {{es-footer}}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ember-percy": "^1.4.2",
     "ember-resolver": "^4.5.6",
     "ember-source": "~3.2.0",
-    "ember-styleguide": "^2.0.0",
+    "ember-styleguide": "^2.1.0",
     "eslint-plugin-ember": "^5.0.0",
     "loader.js": "^4.2.3"
   },


### PR DESCRIPTION
So I don't really understand what's going on with this but all I know is that it's not working correctly without changing how the padding works. @MelSumner let me know if you want me to detail more about this.

Before this change all of the content is super squashed into the middle of the screen:

<img width="1307" alt="screen shot 2018-06-28 at 10 24 11" src="https://user-images.githubusercontent.com/594890/42025831-7ea39a76-7abd-11e8-98ea-d7c053a6e7f6.png">

After this change, the bounds of the "width" of the app are dealt with by the `.container` class: 

<img width="1306" alt="screen shot 2018-06-28 at 10 25 38" src="https://user-images.githubusercontent.com/594890/42025906-a745e45c-7abd-11e8-857f-425655d2d517.png">

I wanted to use container just because I wanted to make sure that the navbar and the content were using the same measure to define their width.
