### PR TITLE
Update job-board-banner.hbs

### DIFF
--- a/app/templates/components/job-board-banner.hbs
+++ b/app/templates/components/job-board-banner.hbs
@@ -2,7 +2,7 @@
   <div class="job-board">
     <a href="http://jobs.emberjs.com">
       <span class="text-yellow"> new</span> Job Board!
-      <img alt="Tomster icon" src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/45544/icon-tomster.png" role="presentation">
+      <img alt="" src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/45544/icon-tomster.png" role="presentation">
     </a>
   </div>
 


### PR DESCRIPTION
the alt attribute should be empty when the role `presentation` is used.