### PR TITLE
update links to the Octane Guides preview

### DIFF
--- a/app/templates/editions/octane.hbs
+++ b/app/templates/editions/octane.hbs
@@ -4,7 +4,8 @@
 </p>
 <ul class="decorative-boxes">
   <li><a href="https://emberjs.github.io/rfcs/0364-roadmap-2018.html">Read The Roadmap RFC</a></li>
-  <li><a href="https://deploy-preview-455--ember-guides.netlify.com/release/upgrading/editions/">Read the Upgrade Guide</a></li>
+  <li><a href="https://octane-guides-preview.emberjs.com/release/getting-started/quick-start/">Try the new app Quick Start</a></li>
+  <li><a href="https://octane-guides-preview.emberjs.com/release/upgrading/editions/">Read the Upgrade Guide</a></li>
   <li><a href="https://guides.emberjs.com/release/reference/syntax-conversion-guide/">Read The Syntax Conversion Guide</a></li>
 </ul>
 


### PR DESCRIPTION
The staging app is up now! So we should update the Octane guides links.