### PR TITLE
fixing missing Tomster image on the editions page

### DIFF
--- a/app/templates/editions/index.hbs
+++ b/app/templates/editions/index.hbs
@@ -19,7 +19,7 @@ Editions also help ensure that Ember users are getting a cohesive, polished expe
 <h2>Editions</h2>
 <ul class="list-imgs">
   <li>
-    <img src="images/tomster-beta.png" alt="" role="presentation"> <br>
+    <img src={{asset-map "images/tomster-beta.png"}} alt="Tomster Beta Mascot" role="presentation"> <br>
     {{link-to "Octane (March 2019)" "editions.octane"}}
   </li>
 </ul>


### PR DESCRIPTION
This is just because we need to use `{{asset-map}}` for any assets that will get fingerprinted 👍 