### PR TITLE
Address didTransition deprecation

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -11,11 +11,12 @@ const Router = EmberRouter.extend({
   navbar: service(),
   metrics: service(),
   fastboot: service(),
+  router: service(),
 
   init() {
     this._super(...arguments);
 
-    this.on('routeDidChange', () => {
+    this.router.on('routeDidChange', () => {
       this.navbar.closePopupMenu();
       this._trackPage();
     })

--- a/app/router.js
+++ b/app/router.js
@@ -12,10 +12,13 @@ const Router = EmberRouter.extend({
   metrics: service(),
   fastboot: service(),
 
-  didTransition() {
+  init() {
     this._super(...arguments);
-    this.navbar.closePopupMenu();
-    this._trackPage();
+
+    this.on('routeDidChange', () => {
+      this.navbar.closePopupMenu();
+      this._trackPage();
+    })
   },
 
   _trackPage() {

--- a/app/router.js
+++ b/app/router.js
@@ -6,9 +6,9 @@ import { get } from '@ember/object';
 import { scheduleOnce } from '@ember/runloop';
 
 const Router = EmberRouter.extend({
-  navbar: service(),
   location: config.locationType,
   rootURL: config.rootURL,
+  navbar: service(),
   metrics: service(),
   fastboot: service(),
 

--- a/app/router.js
+++ b/app/router.js
@@ -9,12 +9,12 @@ const Router = EmberRouter.extend({
   navbar: service(),
   metrics: service(),
   fastboot: service(),
-  router: service(),
+  routerService: service('router'),
 
   init() {
     this._super(...arguments);
 
-    this.router.on('routeDidChange', () => {
+    this.routerService.on('routeDidChange', () => {
       this.navbar.closePopupMenu();
       this._trackPage();
     })

--- a/app/router.js
+++ b/app/router.js
@@ -1,38 +1,9 @@
 import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-import { inject as service } from '@ember/service';
-
 const Router = EmberRouter.extend({
   location: config.locationType,
-  rootURL: config.rootURL,
-  navbar: service(),
-  metrics: service(),
-  fastboot: service(),
-  routerService: service('router'),
-
-  init() {
-    this._super(...arguments);
-
-    this.routerService.on('routeDidChange', () => {
-      this.navbar.closePopupMenu();
-      this._trackPage();
-    })
-  },
-
-  _trackPage() {
-    if(this.fastboot.isFastBoot) {
-      return;
-    }
-
-    const page = this.url;
-    const title = this.getWithDefault('currentRouteName', 'unknown');
-
-    // this is constant for this app and is only used to identify page views in the GA dashboard
-    const hostname = 'www.emberjs.com';
-
-    this.metrics.trackPage({ page, title, hostname });
-  },
+  rootURL: config.rootURL
 });
 
 Router.map(function() {

--- a/app/router.js
+++ b/app/router.js
@@ -2,8 +2,6 @@ import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
 import { inject as service } from '@ember/service';
-import { get } from '@ember/object';
-import { scheduleOnce } from '@ember/runloop';
 
 const Router = EmberRouter.extend({
   location: config.locationType,
@@ -23,19 +21,17 @@ const Router = EmberRouter.extend({
   },
 
   _trackPage() {
-    if(get(this, 'fastboot.isFastBoot')) {
+    if(this.fastboot.isFastBoot) {
       return;
     }
 
-    scheduleOnce('afterRender', this, () => {
-      const page = this.url;
-      const title = this.getWithDefault('currentRouteName', 'unknown');
+    const page = this.url;
+    const title = this.getWithDefault('currentRouteName', 'unknown');
 
-      // this is constant for this app and is only used to identify page views in the GA dashboard
-      const hostname = 'www.emberjs.com';
+    // this is constant for this app and is only used to identify page views in the GA dashboard
+    const hostname = 'www.emberjs.com';
 
-      this.metrics.trackPage({ page, title, hostname });
-    });
+    this.metrics.trackPage({ page, title, hostname });
   },
 });
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,0 +1,32 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default Route.extend({
+  navbar: service(),
+  metrics: service(),
+  fastboot: service(),
+  router: service(),
+
+  init() {
+    this._super(...arguments);
+
+    this.router.on('routeDidChange', () => {
+      this.navbar.closePopupMenu();
+      this._trackPage();
+    })
+  },
+
+  _trackPage() {
+    if(this.fastboot.isFastBoot) {
+      return;
+    }
+
+    const page = this.url;
+    const title = this.getWithDefault('currentRouteName', 'unknown');
+
+    // this is constant for this app and is only used to identify page views in the GA dashboard
+    const hostname = 'www.emberjs.com';
+
+    this.metrics.trackPage({ page, title, hostname });
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -6255,15 +6255,6 @@
         "lodash.defaultsdeep": "^4.6.0"
       }
     },
-    "ember-cli-valid-component-name": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-valid-component-name/-/ember-cli-valid-component-name-1.0.0.tgz",
-      "integrity": "sha1-cVUM44fgIzBl8wswsVEKot++h+8=",
-      "dev": true,
-      "requires": {
-        "silent-error": "^1.0.0"
-      }
-    },
     "ember-cli-version-checker": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
@@ -7700,25 +7691,47 @@
       }
     },
     "ember-source": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.5.1.tgz",
-      "integrity": "sha512-V+HEMiUu74DFWYBuqw1S1ZLBJcSnDDR48iLbN7SuUCYAW4UtTC091xUFzhNYVuZtPOfsmIZXhLaHyqrzQb9YeA==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.8.0.tgz",
+      "integrity": "sha512-iar9EL0AglbwgsLl8jeh++2mnnpBL2u/JUttP6jjkN/pItHfBGlgBtQ3GH0xyG37DH2SbP5bsj3pBM3xm7rTdA==",
       "dev": true,
       "requires": {
         "broccoli-funnel": "^2.0.1",
-        "broccoli-merge-trees": "^2.0.0",
+        "broccoli-merge-trees": "^3.0.2",
         "chalk": "^2.3.0",
+        "ember-cli-babel": "^7.2.0",
         "ember-cli-get-component-path-option": "^1.0.0",
         "ember-cli-is-package-missing": "^1.0.0",
         "ember-cli-normalize-entity-name": "^1.0.0",
         "ember-cli-path-utils": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-valid-component-name": "^1.0.0",
         "ember-cli-version-checker": "^2.1.0",
         "ember-router-generator": "^1.2.3",
         "inflection": "^1.12.0",
         "jquery": "^3.3.1",
-        "resolve": "^1.6.0"
+        "resolve": "^1.9.0"
+      },
+      "dependencies": {
+        "broccoli-merge-trees": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
+          "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^2.0.0"
+          }
+        },
+        "merge-trees": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
+          "integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
+          "dev": true,
+          "requires": {
+            "fs-updater": "^1.0.4",
+            "heimdalljs": "^0.2.5"
+          }
+        }
       }
     },
     "ember-styleguide": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7722,7 +7722,7 @@
       }
     },
     "ember-styleguide": {
-      "version": "github:ember-learn/ember-styleguide#dbc02f53e79ba1c0a627bd211f935e50cd1b4d2c",
+      "version": "github:ember-learn/ember-styleguide#21e01bbdb08c6b914de7b6929fde9f74860030ef",
       "from": "github:ember-learn/ember-styleguide",
       "dev": true,
       "requires": {
@@ -9354,7 +9354,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9375,12 +9376,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9395,17 +9398,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9522,7 +9528,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9534,6 +9541,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9548,6 +9556,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9555,12 +9564,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9579,6 +9590,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9659,7 +9671,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9671,6 +9684,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9756,7 +9770,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9792,6 +9807,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9811,6 +9827,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9854,12 +9871,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11549,19 +11568,22 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -11603,6 +11625,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11611,7 +11634,8 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ember-moment": "^7.8.0",
     "ember-percy": "^1.5.0",
     "ember-resolver": "^5.0.1",
-    "ember-source": "~3.5.0",
+    "ember-source": "~3.8.0",
     "ember-styleguide": "github:ember-learn/ember-styleguide",
     "ember-template-lint": "^v1.0.0-beta.6",
     "ember-tether": "^1.0.0",


### PR DESCRIPTION
Things I have tried:

- `this.on('routeDidChange'` in EmberRouter's `init` - handler not called
- Inject the router service in EmberRouter and add the handler on init - max call stack reached
- Inject the router service in application route and add the handler on init - handler is not called