### PR TITLE
Enable fingerprinting for svg images

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -11,6 +11,7 @@ module.exports = function (defaults) {
     fingerprint: {
       generateAssetMap: true,
       fingerprintAssetMap: true,
+      extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg'],
       exclude: [
         'images/layers-2x.png',
         'images/layers.png',


### PR DESCRIPTION
Currently svg images cannot be used on the "Who uses Ember.js" site.
This adds svg to the default extensions to be fingerprinted.

<hr>

![image](https://user-images.githubusercontent.com/7302/54811298-a93b2680-4c88-11e9-8acf-43fe0bbb77a7.png)

<hr>

![image](https://user-images.githubusercontent.com/7302/54811339-c4a63180-4c88-11e9-9db3-14ba49d48339.png)

This fixes https://github.com/ember-learn/ember-website/pull/278