### PR TITLE
Remove out of date EmberConf 2019 callout

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -26,6 +26,18 @@
 
 @import 'layout';
 
+// any dynamic sections of the site need to be hidden in percy to prevent false
+// positives in the diffs
+@media only percy {
+  .releases-canary code {
+    visibility: hidden;
+  }
+
+  .highcharts-wrapper {
+    visibility: hidden;
+  }
+}
+
 /* Deprecating these colors/variables */
 $blue-color: #3c64b6;
 $black-color: #252525;

--- a/app/styles/pages/_releases.scss
+++ b/app/styles/pages/_releases.scss
@@ -1,12 +1,5 @@
 @import "../mixins/hidpi";
 
-@media only percy {
-  .releases-canary code {
-    visibility: hidden;
-  }
-}
-
-
 .lts-schedule td, .lts-schedule th {
   padding: 10px;
   text-align: center;

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -19,17 +19,6 @@
   </div>
 </div>
 
-<div class="emberconf-callout">
-  <div class="image">
-    <img src="/images/emberconf-2019-logo.svg" alt="EmberConf 2019" width="140px">
-  </div>
-  <div class="text">
-    <h2>EmberConf tickets are now on sale!</h2>
-    <p>Join us March 18–20, 2019 · Portland, OR</p>
-    <a href="//emberconf.com" class="ember-button ember-button--centered">Learn about EmberConf</a>
-  </div>
-</div>
-
 <section class="section">
   <h2 class="text-center">Highly Productive Out of the Box</h2>
 


### PR DESCRIPTION
WAS: EmberConf 2019 callout
IS: No EmberConf 2019 callout

See: `netlify/ember-website/deploy-preview` link below of homepage emberjs.com or Percy!

Note: We need to fix the other Percy's besides the homepage separately, was discussing with @locks on Discord, need to further sync with him.