### PR TITLE
Bump LTS date to 2019

### DIFF
--- a/data/project/ember/lts.md
+++ b/data/project/ember/lts.md
@@ -10,7 +10,7 @@ initialReleaseDate: 2019-04-02
 lastRelease: 3.8.1
 futureVersion: 3.8.2
 channel: lts
-date: 2018-04-02
+date: 2019-04-02
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:


### PR DESCRIPTION
This updates the year on the [releases page](https://emberjs.com/releases/) to be 2019 instead of 2018 for the LTS channel 🎉 
As far as I can tell this is where that data comes from.

![lts-incorrect-date](https://user-images.githubusercontent.com/196410/55647654-12479180-5793-11e9-958d-1f6a0cc0422b.png)
