### PR TITLE
Releases page: Fix release version to 3.9, add LTS dates for 3.8

### DIFF
--- a/app/templates/releases/index.hbs
+++ b/app/templates/releases/index.hbs
@@ -46,6 +46,20 @@
   <tbody>
     <tr>
       <td>
+        3.8
+      </td>
+      <td>
+        Feb 2019
+      </td>
+      <td>
+        Sep 2019
+      </td>
+      <td>
+        Feb 2020
+      </td>
+    </tr>
+    <tr>
+      <td>
         3.4
       </td>
       <td>
@@ -70,20 +84,6 @@
       </td>
       <td>
         Feb 2019
-      </td>
-    </tr>
-    <tr>
-      <td>
-        2.16
-      </td>
-      <td>
-        Oct 2017
-      </td>
-      <td>
-        May 2018
-      </td>
-      <td>
-        Dec 2018
       </td>
     </tr>
   </tbody>

--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -5,7 +5,7 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.8.0
+initialVersion: 3.9.0
 lastRelease: 3.10.0-beta.1
 futureVersion: 3.10.0
 finalVersion: 3.10.0


### PR DESCRIPTION
I removed the 2.16 LTS from the bottom of the list, as I added the 3.8 LTS to the top of the list. Since 2.18 (now the bottom of the list) expired its final support date back in February, it is reasonable to infer that all prior LTS versions are no longer supported. I also bumped the data so that 3.9 is shown as the current latest release, rather than 3.8.