### PR TITLE
Adds Ember Engines on ember ecosystem

### DIFF
--- a/app/templates/learn/index.hbs
+++ b/app/templates/learn/index.hbs
@@ -82,6 +82,10 @@
   <strong>FastBoot</strong>: Server-side rendering library for Ember applications. Check out the <a href="http://www.ember-fastboot.com/quickstart">Quickstart</a> to get up and running, and the <a href="http://www.ember-fastboot.com/docs/user-guide">User Guide</a> for more detailed information.
 </p>
 
+<p>
+  <strong>Ember Engines</strong>: Ember addon that allow multiple logical applications to be composed together into a single application from the user's perspective. Check out their <a href="http://ember-engines.com/guide">interactive documentation</a>.
+</p>
+
 <h2 id="showcase" class="anchorable-toc">Showcase</h2>
 <p>In this section you will find applications that are maintained by the Ember.js teams with the help of contributors. While software is always a work in progress, the goal is to showcase patterns and solutions applied in real-world applications.</p>
 <p>Whether you're simply interested in checking out how some feature is implemented, or you're looking to contribute, one of these projects might pique your interest!</p>

--- a/app/templates/learn/index.hbs
+++ b/app/templates/learn/index.hbs
@@ -83,7 +83,7 @@
 </p>
 
 <p>
-  <strong>Ember Engines</strong>: Ember addon that allow multiple logical applications to be composed together into a single application from the user's perspective. Check out their <a href="http://ember-engines.com/guide">interactive documentation</a>.
+  <strong>Ember Engines</strong>: Ember addon that allow multiple logical applications to be composed together into a single application from the user's perspective. Check out the <a href="http://ember-engines.com/guide">Ember Engines Guides</a>.
 </p>
 
 <h2 id="showcase" class="anchorable-toc">Showcase</h2>

--- a/app/templates/team.hbs
+++ b/app/templates/team.hbs
@@ -51,7 +51,7 @@
   <p class="text-center">
     The Ember CLI core team is responsible for maintaining ember-cli, the command line interface for managing and packaging
     Ember.js applications and addons. The team also maintains many of the addons in the default blueprint as well as
-    fastboot.
+    Fastboot and Ember Engines.
   </p>
 
   <ul class="list-team">

--- a/app/templates/team.hbs
+++ b/app/templates/team.hbs
@@ -51,7 +51,7 @@
   <p class="text-center">
     The Ember CLI core team is responsible for maintaining ember-cli, the command line interface for managing and packaging
     Ember.js applications and addons. The team also maintains many of the addons in the default blueprint as well as
-    Fastboot and Ember Engines.
+    fastboot.
   </p>
 
   <ul class="list-team">


### PR DESCRIPTION
Recently we added Ember Engines on Ember Guides - https://guides.emberjs.com/release/applications/ember-engines/

I think that very important put on ember website the reference to Ember Engines, because he is maintained by ember core team as well 

@jenweber @sivakumar-kailasam 