### PR TITLE
Corrects the release week for 3.11.0

### DIFF
--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -10,7 +10,7 @@ lastRelease: 3.11.0-beta.1
 futureVersion: 3.11.0
 finalVersion: 3.11.0
 channel: beta
-cycleEstimatedFinishDate: 2019-06-16
+cycleEstimatedFinishDate: 2019-06-24
 date: 2019-05-14
 nextDate: 2019-05-20
 changelogPath: CHANGELOG.md


### PR DESCRIPTION
<img width="1023" alt="Screen Shot 2019-06-25 at 5 39 21 PM" src="https://user-images.githubusercontent.com/1351050/60138512-4918bc80-9770-11e9-92ec-32db5a0ac728.png">

