### PR TITLE
Alumnizing Stef from Framework Team

### DIFF
--- a/data/team-member/stefan-penner.md
+++ b/data/team-member/stefan-penner.md
@@ -7,6 +7,5 @@ twitter: 'https://twitter.com/stefanpenner'
 image: spenner.jpg
 added: 2013-04-02T09:06:00.000Z
 teams:
-  - corejs
   - cli
 ---


### PR DESCRIPTION
...but not actually adding him to archive since he's still on CLI as far as I know and I don't _think_ we want folks in multiple places? Maybe if in the future the alums section also listed what teams people were from :)