### PR TITLE
Update stale settings

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,17 +2,13 @@ pulls:
   daysUntilStale: 60
   daysUntilClose: 7
   markComment: >
-    This pull request has been automatically marked as stale because it has not had
-    recent activity. It will be closed if no further activity occurs. Thank you
-    for your contributions.
+    This pull request has been automatically marked stale. If this pull request is something that still needs work, please add a comment and it will remain open, otherwise it will close in 7 days. You are welcome to open a new pull request if you miss the window. Thanks!
 
 issues:
   daysUntilStale: 120
   daysUntilClose: 7
   markComment: >
-    This issue has been automatically marked as stale because it has not had
-    recent activity. It will be closed if no further activity occurs. Thank you
-    for your contributions.
+    This issue has been automatically marked stale. If this issue is something that still needs work, please add a comment and it will remain open, otherwise it will close in 7 days. You are welcome to open a new issue if you miss the window. Thanks!
 
 # Label to use when marking an issue as stale
 staleLabel: stale

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,22 +1,22 @@
-# Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+pulls:
+  daysUntilStale: 60
+  daysUntilClose: 7
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
 
-# Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
-
-# Issues with these labels will never be considered stale
-# exemptLabels:
-#  - pinned
-#  - security
+issues:
+  daysUntilStale: 120
+  daysUntilClose: 7
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
 
 # Label to use when marking an issue as stale
-staleLabel: wontfix
-
-# Comment to post when marking an issue as stale. Set to `false` to disable
-markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+staleLabel: stale
   
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false
+


### PR DESCRIPTION
- Make settings 2x longer for issues. If it's been open for 4mo, seems safe to push to project management tool e.g. GitHub Projects / Notion / other we are using? 
- Change label to `stale` vs. `wontfix` (I can do this manually as well, seems more accurate.)

If we are cool with this, I can make the same changes on ember-blog.