### PR TITLE
Updated release page data for release of 3.11 and beta of 3.12

### DIFF
--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -5,14 +5,14 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.10.0
-lastRelease: 3.11.0-beta.1
-futureVersion: 3.11.0
-finalVersion: 3.11.0
+initialVersion: 3.11.0
+lastRelease: 3.12.0-beta.1
+futureVersion: 3.12.0
+finalVersion: 3.12.0
 channel: beta
-cycleEstimatedFinishDate: 2019-06-24
-date: 2019-05-14
-nextDate: 2019-05-20
+cycleEstimatedFinishDate: 2019-08-26
+date: 2019-06-25
+nextDate: 2019-06-27
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -10,7 +10,7 @@ lastRelease: 3.12.0-beta.1
 futureVersion: 3.12.0
 finalVersion: 3.12.0
 channel: beta
-cycleEstimatedFinishDate: 2019-08-26
+cycleEstimatedFinishDate: 2019-08-06
 date: 2019-06-25
 nextDate: 2019-06-27
 changelogPath: CHANGELOG.md

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.10.0
-initialReleaseDate: 2019-05-14
-lastRelease: 3.10.0
-futureVersion: 3.11.0
+initialVersion: 3.11.0
+initialReleaseDate: 2019-06-25
+lastRelease: 3.11.1
+futureVersion: 3.12.0
 channel: release
-date: 2019-05-14
+date: 2019-06-25
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -4,11 +4,11 @@ baseFileName: ember-data
 filter:
  - /ember-data\./
 repo: emberjs/data
-lastRelease: 3.10.0-beta.1
-futureVersion: 3.10.0-beta.2
-finalVersion: 3.10.0
+lastRelease: 3.12.0-beta.0
+futureVersion: 3.12.0-beta.0
+finalVersion: 3.12.0
 channel: beta
-date: 2019-05-14
+date: 2019-07-26
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ignoreFiles:

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -4,12 +4,12 @@ baseFileName: ember-data
 filter:
   - /ember-data\./
 repo: emberjs/data
-initialVersion: 3.10.0
-initialReleaseDate: 2019-05-14
-lastRelease: 3.10.0
-futureVersion: 3.11.0
+initialVersion: 3.11.0
+initialReleaseDate: 2019-06-28
+lastRelease: 3.11.4
+futureVersion: 3.12.0
 channel: release
-date: 2019-05-14
+date: 2019-07-26
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ---


### PR DESCRIPTION
After waiting a couple of weeks after the blog post came out, I updated the data pages to get the release pages in sync.

Open questions:

1. What is the projected date for 3.12 release? I used change log date for 3.11 release date, since that has been used in the past, but six weeks from change log date is 5th August, which is very soon. Official release is generally quoted as the day the blog post goes out. Six weeks from blog post date is 26th August. Being conservative, I used the later date. Please advise.

2. The Change Log for Ember Data shows version 3.12.0-beta-1, but NPM shows version 3.12-beta-0, and no beta-1. In my changes, I used the latter because it would work.

Notes: In NPM, the LTS tag for ember-source is 3.8.1, even though there is a 3.8.3. The LTS tag for ember-data is 3.4.4, even though 3.8 came out. I hope these are intentional.