### PR TITLE
Use unique titles for each page

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Ember.js - A framework for ambitious web developers</title>
     <meta name="description" content="Ember.js helps developers be more productive out of the box. Designed with developer ergonomics in mind, its friendly APIs help you get your job done—fast.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta property="st:title" content="Ember.js: A framework for ambitious web developers" />

--- a/app/templates/about/legal.hbs
+++ b/app/templates/about/legal.hbs
@@ -1,3 +1,5 @@
+{{title "Legal"}}
+
 <h1 id="legal">Legal</h1>
 
 <section aria-labelledby="legal">

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,3 +1,6 @@
+{{head-layout}}
+{{title "Ember.js"}}
+
 {{#es-header}}
   {{#es-navbar links=links home="/"}}
     {{!-- TODO: add search implementation --}}

--- a/app/templates/community.hbs
+++ b/app/templates/community.hbs
@@ -1,1 +1,3 @@
+{{title "Community"}}
+
 {{outlet}}

--- a/app/templates/community/meetups-getting-started.hbs
+++ b/app/templates/community/meetups-getting-started.hbs
@@ -1,3 +1,5 @@
+{{title "Getting Started"}}
+
 <h1>
   Getting Your Meetup Up and Running
 </h1>

--- a/app/templates/community/meetups/assets.hbs
+++ b/app/templates/community/meetups/assets.hbs
@@ -1,3 +1,5 @@
+{{title "Assets"}}
+
 <h1>
   Ember Meetup Resources
 </h1>

--- a/app/templates/community/meetups/index.hbs
+++ b/app/templates/community/meetups/index.hbs
@@ -1,3 +1,5 @@
+{{title "Meetups"}}
+
 <h1>Meetups Around the World</h1>
 
 <section aria-labelledby="Meetups">

--- a/app/templates/editions/index.hbs
+++ b/app/templates/editions/index.hbs
@@ -1,3 +1,5 @@
+{{title "Editions"}}
+
 <h1>Ember Editions</h1>
 <p>
   Editions are a concept that were introduced to Ember with <a href="https://github.com/emberjs/rfcs/blob/master/text/0364-roadmap-2018.md" target="_blank" rel="noopener">RFC #364 - Ember 2018 Roadmap</a>. An edition represents a cohesive programming model, and releasing a new edition represents a shift in the programming model due to new features and concepts being added to Ember. Ember Octane is the first new edition that was added to Ember.

--- a/app/templates/editions/octane.hbs
+++ b/app/templates/editions/octane.hbs
@@ -1,3 +1,6 @@
+{{title "Editions"}}
+{{title "Octane"}}
+
 <h1>The Octane Edition of Ember</h1>
 <p class="intro">
   The <strong>preview</strong> of Ember Octane has begun. This means that everything here is experimental and subject to change. Keep that in mind while you peruse this information! 

--- a/app/templates/ember-community-survey-2016.hbs
+++ b/app/templates/ember-community-survey-2016.hbs
@@ -1,3 +1,5 @@
+{{title "Community Survey 2016"}}
+
 <div class="survey-wrapper survey-wrapper-header">
   <div class="survey-header survey-container">
     <h1 class="survey-h1">

--- a/app/templates/ember-community-survey-2017.hbs
+++ b/app/templates/ember-community-survey-2017.hbs
@@ -1,3 +1,5 @@
+{{title "Community Survey 2017"}}
+
 <div class="survey-wrapper survey-wrapper-header">
   <div class="survey-header survey-container">
 

--- a/app/templates/ember-community-survey-2018.hbs
+++ b/app/templates/ember-community-survey-2018.hbs
@@ -1,3 +1,5 @@
+{{title "Community Survey 2018"}}
+
 <div class="survey-reminder-wrapper hidden">
   <div class="survey-reminder-container">
     You have <strong class="survey-time-left"></strong> left to submit your response!

--- a/app/templates/ember-community-survey-2019.hbs
+++ b/app/templates/ember-community-survey-2019.hbs
@@ -1,3 +1,5 @@
+{{title "Community Survey 2019"}}
+
 <div class="survey-wrapper survey-wrapper-header">
   <div class="survey-header survey-container">
     <h1 class="survey-h1">

--- a/app/templates/ember-users.hbs
+++ b/app/templates/ember-users.hbs
@@ -1,3 +1,5 @@
+{{title "Who's Using Ember.js"}}
+
 <h1>
   See Who's Using Ember.js
 </h1>

--- a/app/templates/guidelines.hbs
+++ b/app/templates/guidelines.hbs
@@ -1,3 +1,5 @@
+{{title "Community Guidelines"}}
+
 <h1>Ember Community Guidelines</h1>
 
 <p>

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,0 +1,1 @@
+<title>{{model.title}}</title>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,3 +1,5 @@
+{{title "Ember.js - A framework for ambitious web developers" replace=true}}
+
 <div class="about-page--header">
   A framework for<br>
   <span class="bold">ambitious</span> web developers.

--- a/app/templates/learn/index.hbs
+++ b/app/templates/learn/index.hbs
@@ -1,3 +1,5 @@
+{{title "Learn"}}
+
 <h1 id="learningember">Learning Ember.js</h1>
 
 

--- a/app/templates/logos.hbs
+++ b/app/templates/logos.hbs
@@ -1,3 +1,5 @@
+{{title "Branding"}}
+
 <h1>Branding</h1>
 
 <p>

--- a/app/templates/mascots/index.hbs
+++ b/app/templates/mascots/index.hbs
@@ -1,3 +1,5 @@
+{{title "Mascots"}}
+
 <section aria-label="Mascots" class="page__mascots">
   <h1 class="text-center">Tomster and Zoey</h1>
   <p>

--- a/app/templates/releases.hbs
+++ b/app/templates/releases.hbs
@@ -1,3 +1,5 @@
+{{title "Releases"}}
+
 <div class="columns flex-start">
   <div id="subcontent">
     {{outlet}}

--- a/app/templates/releases/beta.hbs
+++ b/app/templates/releases/beta.hbs
@@ -1,3 +1,5 @@
+{{title "Beta"}}
+
 {{#project-listing
     channel="beta"
     channelDescription="Features spend at least six weeks in beta before they can be included in a stable release."

--- a/app/templates/releases/canary.hbs
+++ b/app/templates/releases/canary.hbs
@@ -1,3 +1,5 @@
+{{title "Canary"}}
+
 <h1 class="project-name">{{capitalize "canary"}} Channel</h1>
 
 <p>Canary releases are generated from each commit to the master branch of Ember and Ember Data. They may contain unstable features.</p>

--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -1,3 +1,5 @@
+{{title "LTS"}}
+
 {{#project-listing
   projects=(array model)
   channel="LTS"

--- a/app/templates/releases/release.hbs
+++ b/app/templates/releases/release.hbs
@@ -1,3 +1,5 @@
+{{title "Stable"}}
+
 {{#project-listing
   projects=(array model.ember model.emberData)
   channel="release"

--- a/app/templates/security.hbs
+++ b/app/templates/security.hbs
@@ -1,3 +1,5 @@
+{{title "Security"}}
+
 <h1 id="toc_ember-js-security-policy">Ember.js Security Policy</h1>
 
 <h2 id="toc_reporting-a-bug">Reporting a Bug</h2>

--- a/app/templates/sponsors.hbs
+++ b/app/templates/sponsors.hbs
@@ -1,3 +1,5 @@
+{{title "Sponsors"}}
+
 <h1>Ember Sponsors and Friends</h1>
 
 <p class="intro">

--- a/app/templates/team.hbs
+++ b/app/templates/team.hbs
@@ -1,3 +1,5 @@
+{{title "Team"}}
+
 <h1 class="text-center">The Team Behind Ember</h1>
 
 <section aria-labelledby="team-detail">

--- a/config/environment.js
+++ b/config/environment.js
@@ -41,6 +41,11 @@ module.exports = function(environment) {
         }
       },
     ],
+
+    pageTitle: {
+      separator: ' - ',
+      prepend: true,
+    },
   };
 
   if (environment === 'development') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6837,6 +6837,51 @@
         }
       }
     },
+    "ember-cli-head": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-head/-/ember-cli-head-0.4.1.tgz",
+      "integrity": "sha512-MIgshw5nGil7Q/TU4SDRCsgsiA3wPC9WqOig/g1LlHTNXjR4vH7s/ddG7GTfK5Kt4ZQHJEUDXpd/lIbdBkIQ/Q==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^6.11.0",
+        "ember-cli-htmlbars": "^2.0.3"
+      },
+      "dependencies": {
+        "ember-cli-babel": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+          "dev": true,
+          "requires": {
+            "amd-name-resolver": "1.2.0",
+            "babel-plugin-debug-macros": "^0.2.0-beta.6",
+            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+            "babel-polyfill": "^6.26.0",
+            "babel-preset-env": "^1.7.0",
+            "broccoli-babel-transpiler": "^6.5.0",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-funnel": "^2.0.0",
+            "broccoli-source": "^1.1.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^2.1.2",
+            "semver": "^5.5.0"
+          }
+        },
+        "ember-cli-htmlbars": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.5.tgz",
+          "integrity": "sha512-3f3PAxdnQ/fhQa8XP/3z4RLRgLHxV8j4Ln75aHbRdemOCjBa048KxL9l+acRLhCulbGQCMnLiIUIC89PAzLrcA==",
+          "dev": true,
+          "requires": {
+            "broccoli-persistent-filter": "^1.4.3",
+            "hash-for-dep": "^1.2.3",
+            "json-stable-stringify": "^1.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        }
+      }
+    },
     "ember-cli-htmlbars": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-3.0.1.tgz",
@@ -8695,6 +8740,18 @@
             "semver": "^5.5.0"
           }
         }
+      }
+    },
+    "ember-page-title": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ember-page-title/-/ember-page-title-5.0.2.tgz",
+      "integrity": "sha512-v5K8tfPxdLmZRRdUP0L9ed+ufC1tw+tAhlHslt5MchDwHh192OH1JhDROp6Wci8/Np9kaSCICxS27nXEgXxxsg==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.7.3",
+        "ember-cli-head": "^0.4.0",
+        "ember-cli-htmlbars": "^3.0.1",
+        "ember-copy": "^1.0.0"
       }
     },
     "ember-percy": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-metrics": "^0.13.0",
     "ember-moment": "^7.8.0",
+    "ember-page-title": "^5.0.2",
     "ember-percy": "^1.5.0",
     "ember-resolver": "^5.0.1",
     "ember-source": "~3.10.0",


### PR DESCRIPTION
Adds titles (and subtitles) to each of the pages.  For example, Legal would be "Legal - Ember.js" and LTS releases would be "LTS - Releases - Ember.js".

I preserved the title for the home page "Ember.js - A framework for ambitious web developers".

See: #313

Side note: some Ember.js websites outside of this project use "Ember.js - Foo" while this PR uses "Foo - Ember.js".  We may need to change the naming pattern in the other places OR here.