### PR TITLE
use octane mascot in editions page

### DIFF
--- a/app/templates/editions/index.hbs
+++ b/app/templates/editions/index.hbs
@@ -21,7 +21,9 @@ Editions also help ensure that Ember users are getting a cohesive, polished expe
 <h2>Editions</h2>
 <ul class="list-imgs">
   <li>
-    <img src="/images/tomster-beta.png" alt="Tomster Beta Mascot" role="presentation"> <br>
-    {{link-to "Octane (March 2019)" "editions.octane"}}
+    <img src="/images/tomsters/octane.png" alt="Tomster Octane Mascot" role="presentation"> <br>
+    {{#link-to "editions.octane"}}
+      Octane
+    {{/link-to}}
   </li>
 </ul>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32344/63628724-fa6b8f80-c605-11e9-881b-6558a608fa9c.png)
