### PR TITLE
update description of Octane for the landing page

### DIFF
--- a/app/templates/editions/octane.hbs
+++ b/app/templates/editions/octane.hbs
@@ -9,7 +9,7 @@
 </p>
 <ul class="decorative-boxes">
   <li><a href="https://octane-guides-preview.emberjs.com/release/getting-started/quick-start/">Try the new app Quick Start</a></li>
-  <li><a href="https://octane-guides-preview.emberjs.com/release/getting-started/quick-start/">Read the Guides</a></li>
+  <li><a href="https://octane-guides-preview.emberjs.com/release/templates/">Read the Guides</a></li>
   <li><a href="https://blog.emberjs.com/2019/08/15/octane-release-plan.html">Learn how to prepare</a></li>
   <li><a href="https://emberjs.github.io/rfcs/0364-roadmap-2018.html">Read The Roadmap RFC</a></li>
 </ul>

--- a/app/templates/editions/octane.hbs
+++ b/app/templates/editions/octane.hbs
@@ -1,12 +1,17 @@
 <h1>The Octane Edition of Ember</h1>
 <p class="intro">
-  The <strong>preview</strong> of Ember Octane has begun. This means that everything here is experimental and subject to change. Keep that in mind while you peruse this information! 
+  The <strong>preview</strong> of Ember Octane has begun! This means that everything here is experimental and subject to change. Keep that in mind while you peruse this information.
+</p>
+<p>
+  Ember Octane describes a set of new features that, when taken together, represent a foundational improvement to the way you use Ember.
+  It has modern, streamlined components and state management that make it fun to build web applications.
+  With seamless interoperability for existing apps, teams can migrate at their own pace, while developers building new apps start out with the best that Ember has to offer.
 </p>
 <ul class="decorative-boxes">
-  <li><a href="https://emberjs.github.io/rfcs/0364-roadmap-2018.html">Read The Roadmap RFC</a></li>
   <li><a href="https://octane-guides-preview.emberjs.com/release/getting-started/quick-start/">Try the new app Quick Start</a></li>
-  <li><a href="https://octane-guides-preview.emberjs.com/release/upgrading/editions/">Read the Upgrade Guide</a></li>
-  <li><a href="https://guides.emberjs.com/release/reference/syntax-conversion-guide/">Read The Syntax Conversion Guide</a></li>
+  <li><a href="https://octane-guides-preview.emberjs.com/release/getting-started/quick-start/">Read the Guides</a></li>
+  <li><a href="https://blog.emberjs.com/2019/08/15/octane-release-plan.html">Learn how to prepare</a></li>
+  <li><a href="https://emberjs.github.io/rfcs/0364-roadmap-2018.html">Read The Roadmap RFC</a></li>
 </ul>
 
 <h2>How you can help</h2>
@@ -22,12 +27,23 @@
 
 <h2>Frequently Asked Questions</h2>
 <dl class="dl-faq">
-  <dt>What Happened to Module Unification?</dt>
+  <dt>When will Octane be ready?</dt>
   <dd>
-    Read the full statement about Module Unification on our blog- <a href="https://blog.emberjs.com/2019/03/11/update-on-module-unification-and-octane.html">https://blog.emberjs.com/2019/03/11/update-on-module-unification-and-octane.html</a> 
+    Octane will be available in v3.14 of Ember.
+    As a minor release, all features are opt-in and non-breaking for existing apps.
+    For details, read the <a href="https://blog.emberjs.com/2019/08/15/octane-release-plan.html">Octane release plan</a>.
   </dd>
   <dt>I'm starting a new app at work. Should I use Octane?</dt>
   <dd>
     Octane is in <em>preview</em> mode- there are bound to be rough edges, and upcoming changes. Since we don't know <i>what</i> we don't know just yet, we advise that Octane be used for experimentation only. We recommend that you continue to use stable versions of Ember for new production applications. 
+  </dd>
+  <dt>Where can I get help or ask questions?</dt>
+  <dd>
+    Visit <LinkTo @route="community">the community page</LinkTo> to join the forums or chat!
+    Discord has channels specifically for Octane where you can search for other people's questions too.
+  </dd>
+  <dt>What Happened to Module Unification?</dt>
+  <dd>
+    Read the full statement about Module Unification on our blog- <a href="https://blog.emberjs.com/2019/03/11/update-on-module-unification-and-octane.html">https://blog.emberjs.com/2019/03/11/update-on-module-unification-and-octane.html</a> 
   </dd>
 </dl>


### PR DESCRIPTION
This is a follow up on a to-do item from the last octane team meeting.

The verbage is copy-paste from the Octane Plan blog post. I added a bit to the FAQs as well.