### PR TITLE
Update guides links

### DIFF
--- a/app/templates/editions/octane.hbs
+++ b/app/templates/editions/octane.hbs
@@ -12,7 +12,8 @@
 </p>
 <ul class="decorative-boxes">
   <li><a href="https://octane-guides-preview.emberjs.com/release/getting-started/quick-start/">Try the new app Quick Start</a></li>
-  <li><a href="https://octane-guides-preview.emberjs.com/release/templates/">Read the Guides</a></li>
+  <li><a href="https://octane-guides-preview.emberjs.com/release/tutorial/00-part-1/">Follow the Tutorial</a></li>
+  <li><a href="https://octane-guides-preview.emberjs.com/release/">Read the Guides</a></li>
   <li><a href="https://blog.emberjs.com/2019/08/15/octane-release-plan.html">Learn how to prepare</a></li>
   <li><a href="https://emberjs.github.io/rfcs/0364-roadmap-2018.html">Read The Roadmap RFC</a></li>
 </ul>


### PR DESCRIPTION
Previously the guides link was pointing to the "Templating" section. Also added link to tutorial.