### PR TITLE
bump version listed from 3.12 to 3.13, and 3.13 to 3.14.

### DIFF
--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -5,10 +5,10 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.12.0
-lastRelease: 3.13.0-beta.2
-futureVersion: 3.13.0
-finalVersion: 3.13.0
+initialVersion: 3.13.0
+lastRelease: 3.14.0-beta.2
+futureVersion: 3.14.0
+finalVersion: 3.14.0
 channel: beta
 cycleEstimatedFinishDate: 2019-09-17
 date: 2019-08-12

--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -10,9 +10,9 @@ lastRelease: 3.14.0-beta.2
 futureVersion: 3.14.0
 finalVersion: 3.14.0
 channel: beta
-cycleEstimatedFinishDate: 2019-09-17
-date: 2019-08-12
-nextDate: 2019-08-19
+cycleEstimatedFinishDate: 2019-10-28
+date: 2019-09-25
+nextDate: 2019-10-28
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -5,10 +5,10 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.12.0
+initialVersion: 3.13.0
 initialReleaseDate: 2019-08-05
-lastRelease: 3.12
-futureVersion: 3.13.0
+lastRelease: 3.13
+futureVersion: 3.14.0
 channel: release
 date: 2019-08-05
 changelogPath: CHANGELOG.md

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -4,9 +4,9 @@ baseFileName: ember-data
 filter:
  - /ember-data\./
 repo: emberjs/data
-lastRelease: 3.13.0-beta.0
-futureVersion: 3.13.0-beta.0
-finalVersion: 3.13.0
+lastRelease: 3.14.0-beta.0
+futureVersion: 3.14.0-beta.0
+finalVersion: 3.14.0
 channel: beta
 date: 2019-08-06
 changelogPath: CHANGELOG.md

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -5,11 +5,11 @@ filter:
   - /ember-data\./
 repo: emberjs/data
 initialVersion: 3.13.0
-initialReleaseDate: 2019-08-05
+initialReleaseDate: 2019-09-16
 lastRelease: 3.13.0
 futureVersion: 3.14.0
 channel: release
-date: 2019-08-05
+date: 2019-10-28
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ---

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -4,10 +4,10 @@ baseFileName: ember-data
 filter:
   - /ember-data\./
 repo: emberjs/data
-initialVersion: 3.12.0
+initialVersion: 3.13.0
 initialReleaseDate: 2019-08-05
-lastRelease: 3.12.0
-futureVersion: 3.13.0
+lastRelease: 3.13.0
+futureVersion: 3.14.0
 channel: release
 date: 2019-08-05
 changelogPath: CHANGELOG.md

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -5,7 +5,7 @@ filter:
   - /ember-data\./
 repo: emberjs/data
 initialVersion: 3.13.0
-initialReleaseDate: 2019-09-16
+initialReleaseDate: 2019-09-25
 lastRelease: 3.13.0
 futureVersion: 3.14.0
 channel: release


### PR DESCRIPTION
On the [releases page](https://emberjs.com/releases/release), we refer to version numbers 3.12 and 3.13. This change increments those version numbers to 3.13 and 3.14. 