### PR TITLE
Copy fix to /ember-users page

### DIFF
--- a/app/templates/ember-users.hbs
+++ b/app/templates/ember-users.hbs
@@ -34,12 +34,6 @@
     To add your company or project to this page, <a href="https://github.com/ember-learn/ember-website" rel="nofollow">submit a Pull Request</a>.<br>
     Be sure that your logo has a transparent background and includes adequate white space.<br>
     Additional instructions are in the
-    <a
-      href="https://github.com/ember-learn/ember-website/blob/master/CONTRIBUTING.md#adding-a-user"
-      rel="nofollow noopener"
-      target="_blank"
-    >
-      contributing guide
-    </a>.
+    <a href="https://github.com/ember-learn/ember-website/blob/master/CONTRIBUTING.md#adding-a-user" rel="nofollow noopener" target="_blank">contributing guide</a>.
   </p>
 </section>


### PR DESCRIPTION
The break was adding an unintentional space to the hyperlink.

WAS:
![image](https://user-images.githubusercontent.com/1372946/66335267-82280780-e8ef-11e9-9792-ab65bae45ec8.png)

IS: 
From Percy:
![image](https://user-images.githubusercontent.com/1372946/66335818-a506eb80-e8f0-11e9-99e3-7f929c0030d8.png)
