### PR TITLE
Add some more aria-labels to create discernable links

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -27,7 +27,7 @@
 
 <div class="emberconf-announcement call-to-action__box">
   <div class="logo-and-date">
-    <a href="//emberconf.com/">
+    <a href="//emberconf.com/" aria-label="Visit the EmberConf Website">
       {{svg-jar "emberconf-2020-logo" class="emberconf-logo" alt="EmberConf 2020"}}
     </a>
     <div class="emberconf-date">
@@ -92,16 +92,16 @@
   <h2 class="text-center">Buy Ember.js Gear and Support Development</h2>
 
   <div class="gears">
-    <a href="http://devswag.com/products/ember-sticker" class="gear">
+    <a href="http://devswag.com/products/ember-sticker" class="gear" aria-label="Buy Ember stickers">
       <img src="/images/home/ember-sticker.png" alt="ember stickers">
     </a>
-    <a href="http://devswag.com/products/ember-js-tshirt" class="gear">
+    <a href="http://devswag.com/products/ember-js-tshirt" class="gear" aria-label="Buy Ember Tee Shirt">
       <img src="/images/home/ember-shirt.png" alt="ember tee shirt">
     </a>
-    <a href="http://devswag.com/products/ember-mascot-stickers-4" class="gear">
+    <a href="http://devswag.com/products/ember-mascot-stickers-4" class="gear" aria-label="Buy Tomster stickers">
       <img src="/images/home/ember-hamster-sticker.png" alt="tomster stickers">
     </a>
-    <a href="http://devswag.com/products/ember-mascot-tomster" class="gear">
+    <a href="http://devswag.com/products/ember-mascot-tomster" class="gear" aria-label="Buy Tomster plush toys">
       <img src="/images/home/ember-tomster-plush-2.png" alt="tomster plush toys">
     </a>
   </div>


### PR DESCRIPTION
Using the audit mentioned in #234, I added some aria-labels for the main homepage. These include:

- labels for everything in the "gears" div
- a label for the EmberConf site, linked to the logo

Hope this is useful!