### PR TITLE
Update guidelines page markup

### DIFF
--- a/app/templates/guidelines.hbs
+++ b/app/templates/guidelines.hbs
@@ -1,108 +1,114 @@
-<h1>Ember Community Guidelines</h1>
+<div class="container">
+  <h1>Ember Community Guidelines</h1>
+  <section class="margin-top-medium">
+    <p>
+      Our Community Guidelines / Code of Conduct is designed to make it clear that we believe in tolerance, respect, inclusion and hard work. We’ve built a tremendously impressive community of good people, and our goal is to continue growing along the same trajectory.
+    </p>
+    <p>
+      The internet is <em>full</em> of codes of conduct, employee guidelines, community charters and then some. We’ve custom-written some bits of ours, but for a lot of this, borrowed from people, companies and projects that have already done solid jobs at this very task (see our reference list below). No part of this is an endorsement of any of these people, companies or projects—simply us acknowledging that the specific language we’re referencing seems to mirror our own ideals and intentions.
+    </p>
+  </section>
 
-<p>
-  <br>
-  Our Community Guidelines / Code of Conduct is designed to make it clear that we believe in tolerance, respect, inclusion and hard work. We’ve built a tremendously impressive community of good people, and our goal is to continue growing along the
-  same trajectory.
-</p>
-<p>
-  The internet is <em>full</em> of codes of conduct, employee guidelines, community charters and then some. We’ve custom-written some bits of ours, but for a lot of this, borrowed from people, companies and projects that have already done solid jobs
-  at this very task (see our reference list below). No part of this is an endorsement of any of these people, companies or projects—simply us acknowledging that the specific language we’re referencing seems to mirror our own ideals and intentions.
-</p>
+  <section class="margin-top-medium">
+    <h2>General Goals</h2>
+    <p>We strive to:</p>
+    <ol>
+      <li>
+        <strong>Be open</strong>: We invite anybody, from any company or from no company, to participate in any aspect of our projects. Our community is open, and any responsibility can be carried by any contributor who demonstrates the required capacity and competence.
+      </li>
+      <li>
+        <strong>Be empathetic and respectful</strong>: We work together to resolve conflict, assume good intentions and do our best to act in an empathetic fashion. We don’t allow frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one. We expect community members to resolve disagreements constructively.
+      </li>
+      <li>
+        <strong>Be collaborative</strong>: Collaboration reduces redundancy and improves the quality of our work. We prefer to work transparently and involve interested parties as early as possible. Wherever possible, we work closely with other projects to coordinate our efforts.
+      </li>
+      <li>
+        <strong>Be pragmatic</strong>: Nobody knows everything! Asking questions early avoids problems later, so questions are encouraged, though they may be directed to the appropriate forum. Those who are asked should be responsive and helpful.
+      </li>
+      <li>
+        <strong>Step down considerately</strong>: Members of every project come and go. When somebody leaves or disengages from the project or community, we ask that they do so in a way that minimizes disruption to the rest. They should tell people they are leaving and take the proper steps to ensure that others can pick up where they left off.
+      </li>
+      <li>
+        <strong>Take responsibility for our words and our actions</strong>: We can all make mistakes; when we do, we take responsibility for them. If someone has been harmed or offended, we listen carefully and respectfully, and work to right the wrong.
+      </li>
+    </ol>
+  </section>
 
-<h2>General Goals</h2>
+  <section class="margin-top-medium">
+    <h2>Diversity: Everyone is Welcome</h2>
+    <p>
+      We are committed to being a community that everyone feels good about joining. Although we may not be able to satisfy everyone, we will always work to treat everyone well.
+    </p>
+    <p>
+      We’ll avoid a laundry list of all the things you may and may not be, what classes are legally protected, etc. Whoever you are, wherever you’re from, whatever you look like or identify as, believe in or don’t believe in, know that you’re welcome.
+    </p>
+  </section>
 
-<p>We strive to:</p>
-  <ol>
-    <li>
-      <strong>Be open</strong>: We invite anybody, from any company or from no company, to participate in any aspect of our projects. Our community is open, and any responsibility can be carried by any contributor who demonstrates the required capacity and competence.
-    </li>
-    <li>
-      <strong>Be empathetic and respectful</strong>: We work together to resolve conflict, assume good intentions and do our best to act in an empathetic fashion. We don’t allow frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one. We expect community members to resolve disagreements constructively.
-    </li>
-    <li>
-      <strong>Be collaborative</strong>: Collaboration reduces redundancy and improves the quality of our work. We prefer to work transparently and involve interested parties as early as possible. Wherever possible, we work closely with other projects to coordinate our efforts.
-    </li>
-    <li>
-      <strong>Be pragmatic</strong>: Nobody knows everything! Asking questions early avoids problems later, so questions are encouraged, though they may be directed to the appropriate forum. Those who are asked should be responsive and helpful.
-    </li>
-    <li>
-      <strong>Step down considerately</strong>: Members of every project come and go. When somebody leaves or disengages from the project or community, we ask that they do so in a way that minimizes disruption to the rest. They should tell people they are leaving and take the proper steps to ensure that others can pick up where they left off.
-    </li>
-    <li>
-      <strong>Take responsibility for our words and our actions</strong>: We can all make mistakes; when we do, we take responsibility for them. If someone has been harmed or offended, we listen carefully and respectfully, and work to right the wrong.
-    </li>
-  </ol>
+  <section class="margin-top-medium">
+    <h2>Leadership, Authority and Responsibility</h2>
+    <p>The following list expresses some of our many intentions on these topics:</p>
+    <ol>
+      <li>
+        <strong>Setting the direction</strong>: The ultimate direction of Ember comes from our "benevolent dictators," who delegate specific responsibilities and the corresponding authority to a series of teams and individuals. Currently, the primary
+        group of people directing the project (and with the ability to approve and make substantial changes) is known as the <a href="/team">Ember Core Team</a>. The Ember Core Team is a living body, with members added and removed as project and
+        personal priorities shift. Leadership is not an award, right, or title; it is a privilege, a responsibility and a mandate, and one the Ember Core Team takes seriously.
+      </li>
+      <li>
+        <strong>We delegate</strong>: Good leaders know when to delegate. The best leaders balance delegation with hard work of their own. Of course, leadership doesn’t mean that leaders delegate unpleasant work to others. Instead, leaders balance hard
+        work on their own—leadership by example—with delegation to others. A leader's foremost goal is ensuring that their team members and team succeed.
+      </li>
+      <li>
+        <strong>We lead by example</strong>: The Code of Conduct does not only apply to leaders; it applies to leaders more. Leaders do their very best to show more patience, more respect, and more civility than other members of the Ember community.
+      </li>
+      <li>
+        <strong>We value discussion, data and decisiveness</strong>: We gather opinions, data and commitments from concerned parties before making decisions. Once a reasonable amount of research is performed and data collected, we do our best to move
+        decisively and efficiently. If we make a mistake, we’ll go back and fix it.
+      </li>
+      <li>
+        <strong>We give credit where it’s due</strong>: A good leader does not seek the limelight but aims to congratulate their team for the work they do. While leaders are frequently more visible than their team, leaders in the Ember Community use
+        their visibility to highlight the great work of their team members and others.
+      </li>
+      <li>
+        <strong>We’ll help however we can</strong>: If a community member has a concern, it should be <a href="mailto:ombudsman@emberjs.com">brought to the Core Team</a>. Know that we’ll do our best to help you out of any precarious of uncomfortable
+        positions. Your happiness, productivity and peace of mind is a priority for us.
+      </li>
+    </ol>
+  </section>
 
-<h3>Diversity: Everyone is Welcome</h3>
+  <section class="margin-top-medium">
+    <h2>Conflicts of Interest</h2>
 
-<p>
-  We are committed to being a community that everyone feels good about joining. Although we may not be able to satisfy everyone, we will always work to treat everyone well.
-</p>
-<p>
-  We’ll avoid a laundry list of all the things you may and may not be, what classes are legally protected, etc. Whoever you are, wherever you’re from, whatever you look like or identify as, believe in or don’t believe in, know that you’re welcome.
-</p>
+    <p>
+      We expect leaders and community members to be aware when they are conflicted due to employment or other projects they are involved in, and abstain from or delegate decisions that may be perceived as self-interested.
+    </p>
+    <p>
+      When in doubt, ask for a second opinion. Perceived conflicts of interest are important to address; as a leader, act to ensure that decisions are credible even if they must occasionally be unpopular, difficult or favorable to the interests of one
+      group over another.
+    </p>
+    <p>
+      This Code is not exhaustive or complete, nor is it a rulebook; it serves to express our common goals and sentiments about our community. We expect it to be followed in spirit as much as in the letter.
+    </p>
+  </section>
 
-<h3>Leadership, Authority and Responsibility</h3>
+  <section class="margin-top-medium">
+    <h2>Source Materials</h2>
+    <ol>
+      <li><a href="https://wiki.mozilla.org/Code_of_Conduct/Draft">Mozilla Code of Conduct</a></li>
+      <li><a href="http://www.ubuntu.com/about/about-ubuntu/conduct">Ubuntu Code of Conduct</a></li>
+      <li><a href="https://github.com/twitter/code-of-conduct">Twitter Code of Conduct</a></li>
+    </ol>
 
-<p>The following list expresses some of our many intentions on these topics:</p>
+    <p>You’ll note a lot of language that appears in all three.</p>
+  </section>
 
-<ol>
-  <li>
-    <strong>Setting the direction</strong>: The ultimate direction of Ember comes from our "benevolent dictators," who delegate specific responsibilities and the corresponding authority to a series of teams and individuals. Currently, the primary
-    group of people directing the project (and with the ability to approve and make substantial changes) is known as the <a href="/team">Ember Core Team</a>. The Ember Core Team is a living body, with members added and removed as project and
-    personal priorities shift. Leadership is not an award, right, or title; it is a privilege, a responsibility and a mandate, and one the Ember Core Team takes seriously.
-  </li>
-  <li>
-    <strong>We delegate</strong>: Good leaders know when to delegate. The best leaders balance delegation with hard work of their own. Of course, leadership doesn’t mean that leaders delegate unpleasant work to others. Instead, leaders balance hard
-    work on their own—leadership by example—with delegation to others. A leader's foremost goal is ensuring that their team members and team succeed.
-  </li>
-  <li>
-    <strong>We lead by example</strong>: The Code of Conduct does not only apply to leaders; it applies to leaders more. Leaders do their very best to show more patience, more respect, and more civility than other members of the Ember community.
-  </li>
-  <li>
-    <strong>We value discussion, data and decisiveness</strong>: We gather opinions, data and commitments from concerned parties before making decisions. Once a reasonable amount of research is performed and data collected, we do our best to move
-    decisively and efficiently. If we make a mistake, we’ll go back and fix it.
-  </li>
-  <li>
-    <strong>We give credit where it’s due</strong>: A good leader does not seek the limelight but aims to congratulate their team for the work they do. While leaders are frequently more visible than their team, leaders in the Ember Community use
-    their visibility to highlight the great work of their team members and others.
-  </li>
-  <li>
-    <strong>We’ll help however we can</strong>: If a community member has a concern, it should be <a href="mailto:ombudsman@emberjs.com">brought to the Core Team</a>. Know that we’ll do our best to help you out of any precarious of uncomfortable
-    positions. Your happiness, productivity and peace of mind is a priority for us.
-  </li>
-</ol>
+  <section class="margin-top-medium">
+    <h2>Contact</h2>
+    <p>
+      If you’d like to suggest tweaks to this page, <a href="https://github.com/emberjs/website">submit a pull request</a>. If you’d like to get in touch with someone on the Core Team with a question or concern related to our community guidelines or other larger concerns, email ombudsman@emberjs.com.
+    </p>
 
-<h3>Conflicts of Interest</h3>
-
-<p>
-  We expect leaders and community members to be aware when they are conflicted due to employment or other projects they are involved in, and abstain from or delegate decisions that may be perceived as self-interested.
-</p>
-<p>
-  When in doubt, ask for a second opinion. Perceived conflicts of interest are important to address; as a leader, act to ensure that decisions are credible even if they must occasionally be unpopular, difficult or favorable to the interests of one
-  group over another.
-</p>
-<p>
-  This Code is not exhaustive or complete, nor is it a rulebook; it serves to express our common goals and sentiments about our community. We expect it to be followed in spirit as much as in the letter.
-</p>
-
-<h3>Source Materials</h3>
-
-<ol>
-  <li><a href="https://wiki.mozilla.org/Code_of_Conduct/Draft">Mozilla Code of Conduct</a></li>
-  <li><a href="http://www.ubuntu.com/about/about-ubuntu/conduct">Ubuntu Code of Conduct</a></li>
-  <li><a href="https://github.com/twitter/code-of-conduct">Twitter Code of Conduct</a></li>
-</ol>
-
-<p>You’ll note a lot of language that appears in all three.</p>
-
-<h3>Contact</h3>
-
-<p>
-  If you’d like to suggest tweaks to this page, <a href="https://github.com/emberjs/website">submit a pull request</a>. If you’d like to get in touch with someone on the Core Team with a question or concern related to our community guidelines or other larger concerns, email ombudsman@emberjs.com.
-</p>
-
-<p>
-  As always, for issues, bug reports, pull requests, docs, etc., <a href="https://github.com/ember-learn/ember-website/">GitHub</a> is still the right place to go.
-</p>
+    <p>
+      As always, for issues, bug reports, pull requests, docs, etc., <a href="https://github.com/ember-learn/ember-website/">GitHub</a> is still the right place to go.
+    </p>
+  </section>
+</div>


### PR DESCRIPTION
fixes https://github.com/ember-learn/ember-website/issues/437

Some comments:
- I didn't find a class to highlight the `General Goals` text as on the old page
- I'm not convinced about the padding between the header and the `<h1>` (seems a bit big), but it's due to the container, applying `padding-top-medium` didn't change anything. 