### PR TITLE
update styleguide to use new pre-release from npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9465,8 +9465,9 @@
       }
     },
     "ember-styleguide": {
-      "version": "github:ember-learn/ember-styleguide#e407771f84e46a0b660f6a6c1403c29df6d44583",
-      "from": "github:ember-learn/ember-styleguide#website-redesign-rfc",
+      "version": "4.0.0-0",
+      "resolved": "https://registry.npmjs.org/ember-styleguide/-/ember-styleguide-4.0.0-0.tgz",
+      "integrity": "sha512-oSwbRCLtYsNERsXQWt7EodLbBwPkK9BMGfrLLI6+/d/eEn//6rBOi7BWwB5CfaKG+RgHWbNH2wunmsKW8zIjSg==",
       "dev": true,
       "requires": {
         "@ember/render-modifiers": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-qunit": "^4.4.1",
     "ember-resolver": "^5.0.1",
     "ember-source": "~3.10.0",
-    "ember-styleguide": "github:ember-learn/ember-styleguide#website-redesign-rfc",
+    "ember-styleguide": "^4.0.0-0",
     "ember-template-lint": "^1.3.0",
     "ember-tether": "^1.0.0",
     "eslint-plugin-ember": "^6.2.0",


### PR DESCRIPTION
This removes the need to use github urls and branch markers 🎉 and hopefully it should make Netlify a bit happier 😂 