### PR TITLE
Ember.js 3.12 is promoted to LTS

### DIFF
--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -36,6 +36,20 @@
     <tbody>
       <tr>
         <td>
+          3.12
+        </td>
+        <td>
+          Aug 2019
+        </td>
+        <td>
+          Mar 2020
+        </td>
+        <td>
+          Aug 2020
+        </td>
+      </tr>
+      <tr>
+        <td>
           3.8
         </td>
         <td>


### PR DESCRIPTION
Following the [release of 3.13, 3.12 has now been promoted to LTS][1]. This PR adds 3.12 to the LTS page. The support/bugfix end dates are based on previous releases (i.e. +7 / +5 months).

[1]: https://blog.emberjs.com/2019/09/25/ember-3-13-released.html