### PR TITLE
Updated markup for community page

### DIFF
--- a/app/templates/community/index.hbs
+++ b/app/templates/community/index.hbs
@@ -8,20 +8,14 @@
       <div class="col-4-large">
         <h2 class="margin-bottom-small">Stuck? Lost? Get Help from the Community</h2>
         <p>
-          <a href="http://discuss.emberjs.com">Ember Discussion Forum</a> &mdash; a great venue for discussing features,
-          architecture and best practices.
+          <a href="http://discuss.emberjs.com">Ember Discussion Forum</a> &mdash; a great venue for discussing features, architecture and best practices.
         </p>
         <p>
-          <a href="https://discordapp.com/invite/zT3asNS">Ember Community Discord</a> &mdash; ask questions and chat with
-          community members in real-time. (Looking for the Ember Community Slack? We recently switched away from Slack to <a
-            href="https://discordapp.com">Discord</a>. Read more about why <a
-            href="https://github.com/emberjs/rfcs/pull/345">here</a>).
+          <a href="https://discordapp.com/invite/zT3asNS">Ember Community Discord</a> &mdash; ask questions and chat with community members in real-time. (Looking for the Ember Community Slack? We recently switched away from Slack to <a href="https://discordapp.com">Discord</a>. Read more about why <a href="https://github.com/emberjs/rfcs/pull/345">here</a>).
         </p>
         <p>
           <a href="http://stackoverflow.com/questions/tagged/ember.js">StackOverflow</a> &mdash; used to track questions. Just
-          tag your question with <code>ember.js</code> or <a href="http://stackoverflow.com/questions/tagged/ember.js">search
-            for questions with that tag</a>. Please check to see if your question has already been answered before asking a new
-          one.
+          tag your question with <code>ember.js</code> or <a href="http://stackoverflow.com/questions/tagged/ember.js">search for questions with that tag</a>. Please check to see if your question has already been answered before asking a new one.
         </p>
         <p>
           Please note that these resources are not managed or moderated by the Ember Core Team. They are public forums.
@@ -32,16 +26,13 @@
   <section class="margin-top-medium" aria-labelledby="section-latest-news">
     <h2>Stay Up to Date with the Latest News</h2>
     <p>
-      <a href="https://the-emberjs-times.ongoodbits.com/">Ember.js Times</a> &mdash; follow the progress of new features in
-      the Ember ecosystem, requests for community input (RFCs), and calls for contributors
+      <a href="https://the-emberjs-times.ongoodbits.com/">Ember.js Times</a> &mdash; follow the progress of new features in the Ember ecosystem, requests for community input (RFCs), and calls for contributors
     </p>
     <p>
-      <a href="http://emberweekly.com/">Ember Weekly</a> &mdash; a curated list of Ember learning resources (podcasts,
-      videos, blog posts, books, and more)
+      <a href="http://emberweekly.com/">Ember Weekly</a> &mdash; a curated list of Ember learning resources (podcasts, videos, blog posts, books, and more)
     </p>
     <p>
-      <a href="https://emberjs.com/blog/">Official Ember Blog</a> &mdash; big announcements like new Ember.js version
-      release notes or State of the Union information
+      <a href="https://emberjs.com/blog/">Official Ember Blog</a> &mdash; big announcements like new Ember.js version release notes or State of the Union information
     </p>
   </section>
   <section class="margin-top-medium" aria-labelledby="section-reporting-bugs">
@@ -49,27 +40,18 @@
       <div class="col-4-large">
         <h2>Something Fishy? Report it to the Team</h2>
         <p>
-          If you've found a bug or issue in Ember.js, please let us know. To file a bug, go to the <a
-            href="https://github.com/emberjs/ember.js/issues">issue tracker</a> and create a new issue. Great bug reports
-          include a clear description of what is not happening and what you expected to happen. Issues that include a failing
-          test or a reduced test case created on <a href="https://ember-twiddle.com">Ember Twiddle</a>, <a
-            href="http://jsfiddle.net/6Evrq/">JSFiddle</a> or <a href="http://emberjs.jsbin.com/">JSBin</a> are much more likely
-          to receive attention. See the <a href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full
-            guidelines</a> for more information.
+          If you've found a bug or issue in Ember.js, please let us know. To file a bug, go to the <a href="https://github.com/emberjs/ember.js/issues">issue tracker</a> and create a new issue. Great bug reports include a clear description of what is not happening and what you expected to happen. Issues that include a failing test or a reduced test case created on <a href="https://ember-twiddle.com">Ember Twiddle</a>, <a href="http://jsfiddle.net/6Evrq/">JSFiddle</a> or <a href="http://emberjs.jsbin.com/">JSBin</a> are much more likely
+          to receive attention. See the <a href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full guidelines</a> for more information.
         </p>
         <p>
-          Please do not report security vulnerabilities on the public GitHub issue tracker. The <a href="https://emberjs.com/security">Ember.js
-          Security Policy</a> details the procedure for disclosing security issues.
+          Please do not report security vulnerabilities on the public GitHub issue tracker. The <a href="https://emberjs.com/security">Ember.js Security Policy</a> details the procedure for disclosing security issues.
         </p>
         <p>
-          The source code for this website is also <a href="https://github.com/ember-learn/ember-website">available on
-            GitHub</a>. If you have found a typo or incorrect documentation, please file an issue on the GitHub project page, or
+          The source code for this website is also <a href="https://github.com/ember-learn/ember-website">available on GitHub</a>. If you have found a typo or incorrect documentation, please file an issue on the GitHub project page, or
           even better, submit a pull request.
         </p>
         <p>
-          Ember is an inclusive community that welcomes (and benefits from!) people of all backgrounds. If you're having a
-          non-code issue, <a href="mailto:ombudsman@emberjs.com?subject=Website Help Link">reach out</a>. We do our very best to
-          be sure every Ember user has pleasant interactions and positive experiences. If we can help make you feel more
+          Ember is an inclusive community that welcomes (and benefits from!) people of all backgrounds. If you're having a non-code issue, <a href="mailto:ombudsman@emberjs.com?subject=Website Help Link">reach out</a>. We do our very best to be sure every Ember user has pleasant interactions and positive experiences. If we can help make you feel more
           comfortable or help navigate a trying situation, let us know.
         </p>
       </div>
@@ -86,10 +68,7 @@
       <div class="col-4-large">
         <h2 class="text-center">In a Giving Mood? Contribute to the Project</h2>
         <p>
-          The Ember.js source is hosted on <a href="https://github.com/emberjs/ember.js/">Github</a>. To contribute patches,
-          create a fork of the project on GitHub and submit a pull request. Please be sure to include unit tests and
-          documentation for any new features you add. See the <a
-            href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full guidelines</a> for more information.
+          The Ember.js source is hosted on <a href="https://github.com/emberjs/ember.js/">Github</a>. To contribute patches, create a fork of the project on GitHub and submit a pull request. Please be sure to include unit tests and documentation for any new features you add. See the <a href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full guidelines</a> for more information.
         </p>
       </div>
     </div>
@@ -99,26 +78,22 @@
       <h2>Feeling Lonely? Join a Meetup</h2>
       <img alt="Meetup" src="/images/community/meetup.png">
       <p>
-        Joining an Ember.js meetup is a great way to learn more about Ember, meet other developers, find jobs, etc. Any and
-        all things Ember and local.
+        Joining an Ember.js meetup is a great way to learn more about Ember, meet other developers, find jobs, etc. Any and all things Ember and local.
       </p>
-      <p>
-        {{#link-to "community.meetups" class="es-button"}}
-          Find a meetup
-        {{/link-to}}
-      </p>
+      {{#link-to "community.meetups" class="es-button"}}
+        Find a meetup
+      {{/link-to}}
     </section>
 
     <section class="margin-top-medium col-3-large text-center" aria-labelledby="section-mascots">
       <h2>Met The Mascots? You'll Love Them!</h2>
       <img alt="Campster" src="/images/community/campster.png">
       <p>
-        Tomster and Zoey have been crafted with love, and are constantly getting makeovers. Events, User Groups,
-        Countries&mdash;sky's the limit!
+        Tomster and Zoey have been crafted with love, and are constantly getting makeovers. Events, User Groups, Countries&mdash;sky's the limit!
       </p>
-        {{#link-to "mascots" class="es-button"}}
-          Meet the Mascots
-        {{/link-to}}
+      {{#link-to "mascots" class="es-button"}}
+        Meet the Mascots
+      {{/link-to}}
     </section>
   </div>
   <section class="margin-top-large text-center" aria-labelledby="section-meetup-video">

--- a/app/templates/community/index.hbs
+++ b/app/templates/community/index.hbs
@@ -3,10 +3,10 @@
   <section class="margin-top-large" aria-labelledby="section-community">
     <div class="layout-grid">
       <div class="col-2-large">
-        <img alt="SOS" class="img-fluid" src="/images/community/sos.png">
+        <img alt="" role="presentation" class="img-fluid" src="/images/community/sos.png">
       </div>
       <div class="col-4-large">
-        <h2 class="margin-bottom-small">Stuck? Lost? Get Help from the Community</h2>
+        <h2 id="section-community" class="margin-bottom-small">Stuck? Lost? Get Help from the Community</h2>
         <p>
           <a href="http://discuss.emberjs.com">Ember Discussion Forum</a> &mdash; a great venue for discussing features, architecture and best practices.
         </p>
@@ -24,7 +24,7 @@
     </div>
   </section>
   <section class="margin-top-medium" aria-labelledby="section-latest-news">
-    <h2>Stay Up to Date with the Latest News</h2>
+    <h2 id="section-latest-news">Stay Up to Date with the Latest News</h2>
     <p>
       <a href="https://the-emberjs-times.ongoodbits.com/">Ember.js Times</a> &mdash; follow the progress of new features in the Ember ecosystem, requests for community input (RFCs), and calls for contributors
     </p>
@@ -38,7 +38,7 @@
   <section class="margin-top-medium" aria-labelledby="section-reporting-bugs">
     <div class="layout-grid">
       <div class="col-4-large">
-        <h2>Something Fishy? Report it to the Team</h2>
+        <h2 id="section-reporting-bugs">Something Fishy? Report it to the Team</h2>
         <p>
           If you've found a bug or issue in Ember.js, please let us know. To file a bug, go to the <a href="https://github.com/emberjs/ember.js/issues">issue tracker</a> and create a new issue. Great bug reports include a clear description of what is not happening and what you expected to happen. Issues that include a failing test or a reduced test case created on <a href="https://ember-twiddle.com">Ember Twiddle</a>, <a href="http://jsfiddle.net/6Evrq/">JSFiddle</a> or <a href="http://emberjs.jsbin.com/">JSBin</a> are much more likely
           to receive attention. See the <a href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full guidelines</a> for more information.
@@ -66,7 +66,7 @@
         <img alt="Contribute" class="img-fluid" src="/images/community/give.png">
       </div>
       <div class="col-4-large">
-        <h2 class="text-center">In a Giving Mood? Contribute to the Project</h2>
+        <h2 id="section-contribute-to-ember" class="text-center">In a Giving Mood? Contribute to the Project</h2>
         <p>
           The Ember.js source is hosted on <a href="https://github.com/emberjs/ember.js/">Github</a>. To contribute patches, create a fork of the project on GitHub and submit a pull request. Please be sure to include unit tests and documentation for any new features you add. See the <a href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full guidelines</a> for more information.
         </p>
@@ -75,7 +75,7 @@
   </section>
   <div class="layout-grid">
     <section class="margin-top-medium col-3-large text-center" aria-labelledby="section-meetups">
-      <h2>Feeling Lonely? Join a Meetup</h2>
+      <h2 id="section-meetups">Feeling Lonely? Join a Meetup</h2>
       <img alt="Meetup" src="/images/community/meetup.png">
       <p>
         Joining an Ember.js meetup is a great way to learn more about Ember, meet other developers, find jobs, etc. Any and all things Ember and local.
@@ -86,7 +86,7 @@
     </section>
 
     <section class="margin-top-medium col-3-large text-center" aria-labelledby="section-mascots">
-      <h2>Met The Mascots? You'll Love Them!</h2>
+      <h2 id="section-mascots">Met The Mascots? You'll Love Them!</h2>
       <img alt="Campster" src="/images/community/campster.png">
       <p>
         Tomster and Zoey have been crafted with love, and are constantly getting makeovers. Events, User Groups, Countries&mdash;sky's the limit!

--- a/app/templates/community/index.hbs
+++ b/app/templates/community/index.hbs
@@ -1,122 +1,127 @@
-<h1>
-  Get Involved: Join the Growing Ember.js Community
-</h1>
-
-<section aria-labelledby="community">
-  <h2 class="text-center">Stuck? Lost? Get Help from the Community</h2>
-  <div>
-    <img alt="SOS" class="section-image pull-left" src="/images/community/sos.png">
-    <p>
-      <a href="http://discuss.emberjs.com">Ember Discussion Forum</a> &mdash; a great venue for discussing features, architecture and best practices.
-    </p>
-
-    <p>
-      <a href="https://discordapp.com/invite/zT3asNS">Ember Community Discord</a> &mdash; ask questions and chat with community members in real-time. (Looking for the Ember Community Slack? We recently switched away from Slack to <a href="https://discordapp.com">Discord</a>. Read more about why <a href="https://github.com/emberjs/rfcs/pull/345">here</a>).
-    </p>
-
-    <p>
-      <a href="http://stackoverflow.com/questions/tagged/ember.js">StackOverflow</a> &mdash; used to track questions. Just tag your question with <code>ember.js</code> or <a href="http://stackoverflow.com/questions/tagged/ember.js">search for questions with that tag</a>. Please check to see if your question has already been answered before asking a new one.
-    </p>
-
-    <p>
-      Please note that these resources are not managed or moderated by the Ember Core Team. They are public forums.
-    </p>
-  </div>
-</section>
-
-<section>
-  <h2>Stay Up to Date with the Latest News</h2>
-
-  <div>
-    <p>
-      <a href="https://the-emberjs-times.ongoodbits.com/">Ember.js Times</a> &mdash; follow the progress of new features in the Ember ecosystem, requests for community input (RFCs), and calls for contributors
-    </p>
-    <p>
-      <a href="http://emberweekly.com/">Ember Weekly</a> &mdash; a curated list of Ember learning resources (podcasts, videos, blog posts, books, and more)
-    </p>
-    <p>
-      <a href="https://emberjs.com/blog/">Official Ember Blog</a> &mdash; big announcements like new Ember.js version release notes or State of the Union information
-    </p>
-  </div>
-</section>
-
-<section>
-  <h2 class="text-center">Something Fishy? Report it to the Team</h2>
-
-  <div>
-    <img alt="Bug" class="section-image pull-right" src="/images/community/bug.png">
-    <p>
-      If you've found a bug or issue in Ember.js, please let us know. To file a bug, go to the <a href="https://github.com/emberjs/ember.js/issues">issue tracker</a> and create a new issue. Great bug reports include a clear description of what is not happening and what you expected to happen. Issues that include a failing test or a reduced test case created on <a href="https://ember-twiddle.com">Ember Twiddle</a>, <a href="http://jsfiddle.net/6Evrq/">JSFiddle</a> or <a href="http://emberjs.jsbin.com/">JSBin</a> are much more likely to receive attention. See the <a href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full guidelines</a> for more information.
-    </p>
-
-    <p>
-      Please do not report security vulnerabilities on the public GitHub issue tracker. The {{#link-to "security"}}Ember.js Security Policy{{/link-to}} details the procedure for disclosing security issues.
-    </p>
-
-    <p>
-      The source code for this website is also <a href="https://github.com/ember-learn/ember-website">available on GitHub</a>. If you have found a typo or incorrect documentation, please file an issue on the GitHub project page, or even better, submit a pull request.
-    </p>
-
-    <p>
-      Ember is an inclusive community that welcomes (and benefits from!) people of all backgrounds. If you're having a non-code issue, <a href="mailto:ombudsman@emberjs.com?subject=Website Help Link">reach out</a>. We do our very best to be sure every Ember user has pleasant interactions and positive experiences. If we can help make you feel more comfortable or help navigate a trying situation, let us know.
-    </p>
-  </div>
-</section>
-
-<section>
-  <h2 class="text-center">In a Giving Mood? Contribute to the Project</h2>
-
-  <div>
-    <img
-      alt="Contribute"
-      class="section-image pull-left"
-      src="/images/community/give.png"
-    >
-    <p>
-      The Ember.js source is hosted on <a href="https://github.com/emberjs/ember.js/">Github</a>. To contribute patches, create a fork of the project on GitHub and submit a pull request. Please be sure to include unit tests and documentation for any new features you add. See the <a href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full guidelines</a> for more information.
-    </p>
-  </div>
-</section>
-
-<section class="section-split">
-  <div class="section-split-item text-center">
-    <h2 class="text-center">Feeling Lonely?<br>Join a Meetup</h2>
-
-    <img alt="Meetup" src="/images/community/meetup.png">
-    <p>
-      Joining an Ember.js meetup is a great way to learn more about Ember, meet other developers, find jobs, etc. Any and all things Ember and local.
-    </p>
-
-    {{#link-to "community.meetups" class="es-button"}}
-      Find a meetup
-    {{/link-to}}
-  </div>
-
-  <div class="section-split-item text-center">
-
-    <h2 class="text-center">Met The Mascots?<br>You'll Love Them!</h2>
-
-    <img alt="Campster" src="/images/community/campster.png">
-    <p>
-      Tomster and Zoey have been crafted with love, and are constantly getting makeovers. Events, User Groups, Countries&mdash;sky's the limit!
-    </p>
-    {{#link-to "mascots" class="es-button"}}
-      Meet the Mascots
-    {{/link-to}}
-  </div>
-</section>
-
-<section class="meetup-video">
-  <div class="video">
-    <div class="embedded-video">
-      <iframe
-        width="640"
-        height="360"
-        src="https://www.youtube.com/embed/rY5D38RQoEg?rel=0"
-        frameborder="0"
-        allowfullscreen
-      >
-      </iframe>
+<div class="container">
+  <h1>Get Involved: Join the Growing Ember.js Community</h1>
+  <section class="margin-top-large" aria-labelledby="section-community">
+    <div class="layout-grid">
+      <div class="col-2-large">
+        <img alt="SOS" class="img-fluid" src="/images/community/sos.png">
+      </div>
+      <div class="col-4-large">
+        <h2 class="margin-bottom-small">Stuck? Lost? Get Help from the Community</h2>
+        <p>
+          <a href="http://discuss.emberjs.com">Ember Discussion Forum</a> &mdash; a great venue for discussing features,
+          architecture and best practices.
+        </p>
+        <p>
+          <a href="https://discordapp.com/invite/zT3asNS">Ember Community Discord</a> &mdash; ask questions and chat with
+          community members in real-time. (Looking for the Ember Community Slack? We recently switched away from Slack to <a
+            href="https://discordapp.com">Discord</a>. Read more about why <a
+            href="https://github.com/emberjs/rfcs/pull/345">here</a>).
+        </p>
+        <p>
+          <a href="http://stackoverflow.com/questions/tagged/ember.js">StackOverflow</a> &mdash; used to track questions. Just
+          tag your question with <code>ember.js</code> or <a href="http://stackoverflow.com/questions/tagged/ember.js">search
+            for questions with that tag</a>. Please check to see if your question has already been answered before asking a new
+          one.
+        </p>
+        <p>
+          Please note that these resources are not managed or moderated by the Ember Core Team. They are public forums.
+        </p>
+      </div>
     </div>
+  </section>
+  <section class="margin-top-medium" aria-labelledby="section-latest-news">
+    <h2>Stay Up to Date with the Latest News</h2>
+    <p>
+      <a href="https://the-emberjs-times.ongoodbits.com/">Ember.js Times</a> &mdash; follow the progress of new features in
+      the Ember ecosystem, requests for community input (RFCs), and calls for contributors
+    </p>
+    <p>
+      <a href="http://emberweekly.com/">Ember Weekly</a> &mdash; a curated list of Ember learning resources (podcasts,
+      videos, blog posts, books, and more)
+    </p>
+    <p>
+      <a href="https://emberjs.com/blog/">Official Ember Blog</a> &mdash; big announcements like new Ember.js version
+      release notes or State of the Union information
+    </p>
+  </section>
+  <section class="margin-top-medium" aria-labelledby="section-reporting-bugs">
+    <div class="layout-grid">
+      <div class="col-4-large">
+        <h2>Something Fishy? Report it to the Team</h2>
+        <p>
+          If you've found a bug or issue in Ember.js, please let us know. To file a bug, go to the <a
+            href="https://github.com/emberjs/ember.js/issues">issue tracker</a> and create a new issue. Great bug reports
+          include a clear description of what is not happening and what you expected to happen. Issues that include a failing
+          test or a reduced test case created on <a href="https://ember-twiddle.com">Ember Twiddle</a>, <a
+            href="http://jsfiddle.net/6Evrq/">JSFiddle</a> or <a href="http://emberjs.jsbin.com/">JSBin</a> are much more likely
+          to receive attention. See the <a href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full
+            guidelines</a> for more information.
+        </p>
+        <p>
+          Please do not report security vulnerabilities on the public GitHub issue tracker. The <a href="https://emberjs.com/security">Ember.js
+          Security Policy</a> details the procedure for disclosing security issues.
+        </p>
+        <p>
+          The source code for this website is also <a href="https://github.com/ember-learn/ember-website">available on
+            GitHub</a>. If you have found a typo or incorrect documentation, please file an issue on the GitHub project page, or
+          even better, submit a pull request.
+        </p>
+        <p>
+          Ember is an inclusive community that welcomes (and benefits from!) people of all backgrounds. If you're having a
+          non-code issue, <a href="mailto:ombudsman@emberjs.com?subject=Website Help Link">reach out</a>. We do our very best to
+          be sure every Ember user has pleasant interactions and positive experiences. If we can help make you feel more
+          comfortable or help navigate a trying situation, let us know.
+        </p>
+      </div>
+      <div class="col-2-large">
+        <img alt="Bug" class="img-fluid" src="/images/community/bug.png">
+      </div>
+    </div>
+  </section>
+  <section class="margin-top-medium" aria-labelledby="section-contribute-to-ember">
+    <div class="layout-grid">
+      <div class="col-2-large">
+        <img alt="Contribute" class="img-fluid" src="/images/community/give.png">
+      </div>
+      <div class="col-4-large">
+        <h2 class="text-center">In a Giving Mood? Contribute to the Project</h2>
+        <p>
+          The Ember.js source is hosted on <a href="https://github.com/emberjs/ember.js/">Github</a>. To contribute patches,
+          create a fork of the project on GitHub and submit a pull request. Please be sure to include unit tests and
+          documentation for any new features you add. See the <a
+            href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full guidelines</a> for more information.
+        </p>
+      </div>
+    </div>
+  </section>
+  <div class="layout-grid">
+    <section class="margin-top-medium col-3-large text-center" aria-labelledby="section-meetups">
+      <h2>Feeling Lonely? Join a Meetup</h2>
+      <img alt="Meetup" src="/images/community/meetup.png">
+      <p>
+        Joining an Ember.js meetup is a great way to learn more about Ember, meet other developers, find jobs, etc. Any and
+        all things Ember and local.
+      </p>
+      <p>
+        {{#link-to "community.meetups" class="es-button"}}
+          Find a meetup
+        {{/link-to}}
+      </p>
+    </section>
+
+    <section class="margin-top-medium col-3-large text-center" aria-labelledby="section-mascots">
+      <h2>Met The Mascots? You'll Love Them!</h2>
+      <img alt="Campster" src="/images/community/campster.png">
+      <p>
+        Tomster and Zoey have been crafted with love, and are constantly getting makeovers. Events, User Groups,
+        Countries&mdash;sky's the limit!
+      </p>
+        {{#link-to "mascots" class="es-button"}}
+          Meet the Mascots
+        {{/link-to}}
+    </section>
   </div>
-</section>
+  <section class="margin-top-large text-center" aria-labelledby="section-meetup-video">
+    <iframe width="854" height="480" src="https://www.youtube.com/embed/rY5D38RQoEg?rel=0" frameborder="0" allowfullscreen></iframe>
+  </section>
+</div>


### PR DESCRIPTION
fixes #432 

There was no style for floated images so I used the `layout-grid` class and put them in a 2 col space with the text in a 4 col space beside them. Some of the images are not high res enough and look a bit pixelated.

Also I bumped the video res from 640x360 to 854x480 to make it fit better under the 2 col layout above it.