### PR TITLE
Updated markup for About - Who Uses Ember page

### DIFF
--- a/app/controllers/ember-users.js
+++ b/app/controllers/ember-users.js
@@ -7,4 +7,4 @@ export default Controller.extend({
 
   sortingKey: Object.freeze(['featured:desc', 'added']),
   sortedModel: sort('model', 'sortingKey')
-})
+});

--- a/app/templates/ember-users.hbs
+++ b/app/templates/ember-users.hbs
@@ -1,43 +1,41 @@
-<h1>
-  See Who's Using Ember.js
-</h1>
+<section class="container" aria-labelledby="ember-users">
+  <h1 id="ember-users">
+    See Who's Using Ember.js
+  </h1>
 
-<p>
-  Logos are added by company representatives. These companies may or may not be using Ember on their main web properties, but they're definitely using it somewhere in their organizations!
-</p>
-<p>
-  Feel free to track down folks who work at a specific company if you're looking for more detail on their specific usage.
-</p>
-
-<section aria-labelledby="Ember user list">
-  <ul class="user-showcase">
-    {{#each sortedModel as |user|}}
-      <li>
-        <a
-          class="user-showcase__link"
-          href={{user.url}}
-          rel="nofollow noopener"
-          target="_blank"
-        >
-          <img
-            src={{asset-map (concat "images/users/" user.image)}}
-            alt={{user.name}}
-          >
-        </a>
-      </li>
-    {{/each}}
-  </ul>
-
-  <p class="text-center">
-    To add your company or project to this page, <a href="https://github.com/ember-learn/ember-website" rel="nofollow">submit a Pull Request</a>.<br>
-    Be sure that your logo has a transparent background and includes adequate white space.<br>
-    Additional instructions are in the
-    <a
-      href="https://github.com/ember-learn/ember-website/blob/master/CONTRIBUTING.md#adding-a-user"
-      rel="nofollow noopener"
-      target="_blank"
-    >
-      contributing guide
-    </a>.
+  <p>
+    Logos are added by company representatives. These companies may or may not be using Ember on their main web properties, but they're definitely using it somewhere in their organizations!
   </p>
+  <p>
+    Feel free to track down folks who work at a specific company if you're looking for more detail on their specific usage.
+  </p>
+
+  <section aria-labelledby="section-ember-users-list-of-companies">
+    <h2 id="section-ember-users-list-of-companies">List of Companies</h2>
+
+    <ul class="list-unstyled layout-grid">
+      {{#each this.sortedModel as |user|}}
+        <EsCard
+          class="col-1-large"
+          @image={{asset-map (concat "images/users/" user.image)}}
+          @alt={{user.name}}
+          card-link horizontal full-image vertical
+        >
+          <h3>
+            <a href={{user.url}} rel="nofollow noopener" target="_blank">
+              {{user.name}}
+            </a>
+          </h3>
+        </EsCard>
+      {{/each}}
+    </ul>
+  </section>
+
+  <section aria-labelledby="section-ember-users-please-introduce-yourself">
+    <h2 id="section-ember-users-please-introduce-yourself">Please Introduce Yourself!</h2>
+
+    <p>
+      To add your company or project to this page, <a href="https://github.com/ember-learn/ember-website" rel="nofollow noopener">submit a Pull Request</a>. Be sure that your logo has a transparent background and includes adequate white space. Additional instructions are in the <a href="https://github.com/ember-learn/ember-website/blob/master/CONTRIBUTING.md#adding-a-user" rel="nofollow noopener" target="_blank">contributing guide</a>.
+    </p>
+  </section>
 </section>

--- a/app/templates/ember-users.hbs
+++ b/app/templates/ember-users.hbs
@@ -17,15 +17,14 @@
       {{#each this.sortedModel as |user|}}
         <EsCard
           class="col-1-large"
-          @alt=""
-          @image={{asset-map (concat "images/users/" user.image)}}
-          card-link horizontal full-image vertical
+          card-link vertical
         >
-          <h3>
-            <a href={{user.url}} rel="nofollow noopener" target="_blank">
-              {{user.name}}
-            </a>
-          </h3>
+          <a href={{user.url}} rel="nofollow noopener" target="_blank">
+            <img
+              alt={{user.name}}
+              src={{asset-map (concat "images/users/" user.image)}}
+            >
+          </a>
         </EsCard>
       {{/each}}
     </ul>

--- a/app/templates/ember-users.hbs
+++ b/app/templates/ember-users.hbs
@@ -17,8 +17,8 @@
       {{#each this.sortedModel as |user|}}
         <EsCard
           class="col-1-large"
+          @alt=""
           @image={{asset-map (concat "images/users/" user.image)}}
-          @alt={{user.name}}
           card-link horizontal full-image vertical
         >
           <h3>


### PR DESCRIPTION
This PR addresses the issue #436 . In addition to the styleguide doc, I looked at PRs #450 and #455 for reference.

There are a few remaining issues that I couldn't solve on first attempt:

- The doc suggests, in order to use `card-link` option to make the entire `<EsCard>` interactive, I'd need to yield an `<a>` tag. Since an anchor needs text (content), I temporarily added the company's name. I'm not sure if there's an additional class name or attribute that I can pass to the card to make the text invisible.
  - An alternative approach may be to not use `@image` attribute, but instead add `<img>` tag inside the `<a>` tag, as done previously?
- (1) I wasn't sure how to set class names to render fewer cards for smaller resolutions. (2) The current Ember website shows 5, 3, 2, or 1 card(s). With the new 6-column layout, I wasn't sure how many cards I was supposed to show and when.
- There is no bottom margin for `<ul class="list-unstyled layout-grid">`. As a result, whatever content would come next touches the cards too closely.

As an aside, making the entire `<EsCard>` interactive required me to surround the `<a>` tag with an `<h3>`. To avoid jumping from `h1` to `h3`, I added `<h2>` tag with the name `List of Companies`.

The text at the end of this page describes how one can add their company or project to the list. I wasn't sure if this text, semantically, belongs under `List of Companies`. For now, I placed it in a separate `h2`. Alternatively, I think we could look at using `<aside>` to place the text back under `List of Companies`?

[end of aside]

Before (desktop):
<img width="1680" alt="Screen Shot 2019-10-30 at 8 15 58 PM" src="https://user-images.githubusercontent.com/16869656/67911071-23068d00-fb53-11e9-9fd6-5ff44b0f7b13.png">

Before (mobile, w=520px):
<img width="400" alt="Screen Shot 2019-10-30 at 8 16 58 PM" src="https://user-images.githubusercontent.com/16869656/67911074-239f2380-fb53-11e9-9f8e-b609dab28d23.png">

Before (additional text at end):
<img width="1680" alt="Screen Shot 2019-10-30 at 8 17 29 PM" src="https://user-images.githubusercontent.com/16869656/67911075-239f2380-fb53-11e9-83c5-9d9f5856c4d8.png">

After (desktop):
<img width="1680" alt="Screen Shot 2019-10-30 at 8 16 11 PM" src="https://user-images.githubusercontent.com/16869656/67911072-23068d00-fb53-11e9-8528-bb79bb683537.png">

After (mobile, w=520px):
<img width="400" alt="Screen Shot 2019-10-30 at 8 16 47 PM" src="https://user-images.githubusercontent.com/16869656/67911073-23068d00-fb53-11e9-9ed7-27d877cb4f72.png">

After (additional text at end):
<img width="1680" alt="Screen Shot 2019-10-30 at 8 17 37 PM" src="https://user-images.githubusercontent.com/16869656/67911076-239f2380-fb53-11e9-9b04-2257782d57d6.png">
