### PR TITLE
Update community meetup page

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -7,3 +7,11 @@
     visibility: hidden;
   }
 }
+
+.leaflet-container {
+   height: 400px;
+ }
+
+.align-middle {
+  vertical-align: middle;
+}

--- a/app/templates/community/meetups/index.hbs
+++ b/app/templates/community/meetups/index.hbs
@@ -1,7 +1,7 @@
 <div class="container">
-  <h1>Meetups Around the World</h1>
+  <h1 class="mb-3">Meetups Around the World</h1>
 
-  <section aria-labelledby="meetups" class="margin-top-medium">
+  <section aria-labelledby="meetups" class="mb-3">
     <h2 id="meetups">Find a meetup in your city</h2>
     {{#leaflet-map lat=lat lng=lng zoom=zoom}}
       {{tile-layer url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
@@ -21,14 +21,14 @@
       {{/each}}
     {{/leaflet-map}}
 
-    <div class="margin-top-medium">
+    <div>
       {{#each sortedMeetupsByArea as |area|}}
-        <div class="margin-top-small">
+        <div class="mt-3">
           <h3>{{area.value}}</h3>
-          <ul class="list-unstyled layout-grid">
+          <ul class="list-unstyled grid lg:grid-4 sm:grid-2">
             {{#each area.items as |meetup|}}
-              <li class="col-2-large col-4">
-                <img class="icon icon-left" src="/images/meetups/map-pin.png" alt="location icon" role="presentation" style="width: 0.7em">
+              <li>
+                <img width="12" class="align-middle icon-left" src="/images/meetups/map-pin.png" alt="location icon" role="presentation">
                 <a href={{meetup.url}}>{{meetup.location}}</a>
               </li>
             {{/each}}
@@ -38,7 +38,7 @@
     </div>
   </section>
 
-  <section aria-labelledby="start-your-meetup" class="margin-top-medium">
+  <section aria-labelledby="start-your-meetup">
     <h2 id="start-your-meetup">Start your own meetup</h2>
     <img alt="Meetup" src="/images/community/meetup.png" align="left" role="presentation">
     <p>

--- a/app/templates/community/meetups/index.hbs
+++ b/app/templates/community/meetups/index.hbs
@@ -1,57 +1,48 @@
-<h1>Meetups Around the World</h1>
+<div class="container">
+  <h1>Meetups Around the World</h1>
 
-<section aria-labelledby="Meetups">
+  <section aria-labelledby="meetups" class="margin-top-medium">
+    <h2 id="meetups">Find a meetup in your city</h2>
+    {{#leaflet-map lat=lat lng=lng zoom=zoom}}
+      {{tile-layer url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
 
-  <h2>Find a meetup in your city</h2>
+      {{#each model as |meetup|}}
+        {{#marker-layer lat=meetup.lat lng=meetup.lng}}
+          {{#popup-layer}}
+            <a
+              href={{meetup.url}}
+              target="_blank"
+              rel="noopener"
+              >
+              {{meetup.location}}
+            </a>
+          {{/popup-layer}}
+        {{/marker-layer}}
+      {{/each}}
+    {{/leaflet-map}}
 
+    <div class="margin-top-medium">
+      {{#each sortedMeetupsByArea as |area|}}
+        <div class="margin-top-small">
+          <h3>{{area.value}}</h3>
+          <ul class="list-unstyled layout-grid">
+            {{#each area.items as |meetup|}}
+              <li class="col-2-large col-4">
+                <img class="icon icon-left" src="/images/meetups/map-pin.png" alt="location icon" role="presentation" style="width: 0.7em">
+                <a href={{meetup.url}}>{{meetup.location}}</a>
+              </li>
+            {{/each}}
+          </ul>
+        </div>
+      {{/each}}
+    </div>
+  </section>
 
-  {{#leaflet-map class="leaflet-container" lat=lat lng=lng zoom=zoom}}
-    {{tile-layer url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"}}
-
-    {{#each model as |meetup|}}
-      {{#marker-layer lat=meetup.lat lng=meetup.lng}}
-        {{#popup-layer}}
-          <a
-            href={{meetup.url}}
-            target="_blank"
-            rel="noopener"
-          >
-            {{meetup.location}}
-          </a>
-
-          {{!-- image: 02boston.png --}}
-        {{/popup-layer}}
-      {{/marker-layer}}
-    {{/each}}
-  {{/leaflet-map}}
-
-</section>
-
-<section>
-  <div class="meetup-locations-grid">
-    {{#each sortedMeetupsByArea as |area|}}
-      <div class="meetup-locations-grid-item">
-        <h3>
-          {{area.value}}
-        </h3>
-        <ul class="meetup-locations">
-          {{#each area.items as |meetup|}}
-            <li>
-              <a href={{meetup.url}}>{{meetup.location}}</a>
-            </li>
-          {{/each}}
-        </ul>
-      </div>
-    {{/each}}
-  </div>
-</section>
-
-<section>
-  <h2>Start your own meetup</h2>
-  <div>
-    <img alt="Meetup" class="pull-left" src="/images/community/meetup.png">
+  <section aria-labelledby="start-your-meetup" class="margin-top-medium">
+    <h2 id="start-your-meetup">Start your own meetup</h2>
+    <img alt="Meetup" src="/images/community/meetup.png" align="left" role="presentation">
     <p>
-      Ready to start a Meetup in your area? Fantastic news—appreciate you stepping up! Running a solid meetup isn't all that complicated, but it <em>can</em> be intimidating:<br>
+      Ready to start a Meetup in your area? Fantastic news—appreciate you stepping up! Running a solid meetup isn't all that complicated, but it <strong>can</strong> be intimidating:<br>
       we'd love to help you ease into it.
     </p>
     <p>
@@ -60,8 +51,5 @@
     <p>
       <a href="mailto:meetups@emberjs.com">Send us a note</a> if you have questions or need a hand.
     </p>
-  </div>
-  <div class="clearfix">
-
-  </div>
-</section>
+  </section>
+</div>


### PR DESCRIPTION
Fixes https://github.com/ember-learn/ember-website/issues/433

More styles are needed to finish this page. Specifically:
- For the map to be visible, there should be styles for the `leaflet-container` class with the size of the container. On the previous version it was:
```css
  .leaflet-container {
    height: 400px;
  }
```
- The location icons (previously part of the `<li>` styles) were added here as images, but I had to add inline-styles for now to make the sizing similar to what it was. 
- The list of locations was previously shown in 4 columns, with the current grid is a bit hard to do that. I tried `col-1` but some names are long and the text gets wrapped, so I went with `col-2-large col-4`. 

| Desktop | Mobile| 
| ---|---|
|<img width="1173" alt="Screen Shot 2019-11-01 at 16 47 18" src="https://user-images.githubusercontent.com/5116277/68039716-02624280-fccd-11e9-8e1c-3ccd50d629f1.png">|![image](https://user-images.githubusercontent.com/5116277/68040768-4b1afb00-fccf-11e9-9eff-5fb221fc6b8e.png)|

- For the bottom part (coffee cup image with text) I made the image align left of the text, but in some cases in mobile it doesn't look that good, maybe the image should be a bit smaller:

<img width="247" alt="Screen Shot 2019-11-01 at 17 40 13" src="https://user-images.githubusercontent.com/5116277/68040599-ee1f4500-fcce-11e9-9201-f544221429f2.png">

- `<em>` don't show in italics, so I switched for a `<strong>`, but not sure it's the right call.

| Before (previous website) | After |
|---|---|
|<img width="226" alt="Screen Shot 2019-11-01 at 17 40 28" src="https://user-images.githubusercontent.com/5116277/68041034-ed3ae300-fccf-11e9-8658-d2148d046ed4.png">|![image](https://user-images.githubusercontent.com/5116277/68041048-faf06880-fccf-11e9-87e8-99b92e1b979b.png)|
