### PR TITLE
Updated markup for About - Sponsors page

### DIFF
--- a/app/templates/sponsors.hbs
+++ b/app/templates/sponsors.hbs
@@ -1,38 +1,57 @@
-<h1>Ember Sponsors and Friends</h1>
+<section class="container" aria-labelledby="ember-sponsors-and-friends">
+  <h1 id="ember-sponsors-and-friends">
+    Ember Sponsors and Friends
+  </h1>
 
-<p class="intro">
-  Since its beginnings in 2011, Ember has only gotten as far as we have due to the support&mdash;both financial and technical&mdash;of the following companies:
-</p>
+  <p>
+    Since its beginnings in 2011, Ember has only gotten as far as we have due to the support&mdash;both financial and technical&mdash;of the following companies:
+  </p>
 
-<div class="sponsors section">
-  <h2 class="text-center">Current Sponsors</h2>
+  <section aria-labelledby="ember-sponsors-and-friends-current-sponsors">
+    <h2 id="ember-sponsors-and-friends-current-sponsors">Current Sponsors</h2>
 
-  <ul class="sponsors-list">
-    {{#each currentSponsors as |user|}}
-      <li class="sponsors-list-item">
-        <a href={{user.url}}>
-          <img alt={{user.term}} src={{asset-map (concat "images/users/" user.image)}}>
-        </a>
-        <h3>{{user.term}}</h3>
-        <p id="sponsorType">{{user.content}}</p>
-      </li>
-    {{/each}}
-  </ul>
+    <ul class="list-unstyled layout-grid">
+      {{#each this.currentSponsors as |sponsor|}}
+        <EsCard
+          class="col-2-large"
+          @alt=""
+          @image={{asset-map (concat "images/users/" sponsor.image)}}
+          card-link full-image vertical
+        >
+          <h3>
+            <a href={{sponsor.url}} rel="nofollow noopener" target="_blank">
+              {{sponsor.content}}
+            </a>
+          </h3>
+          <p>{{sponsor.term}}</p>
+        </EsCard>
+      {{/each}}
+    </ul>
+  </section>
 
-  <h2 class="text-center">Past Sponsors</h2>
+  <section aria-labelledby="ember-sponsors-and-friends-past-sponsors">
+    <h2 id="ember-sponsors-and-friends-past-sponsors">Past Sponsors</h2>
 
-  <ul class="sponsors-list">
-    {{#each pastSponsors as |user|}}
-      <li class="sponsors-list-item">
-        <a href={{user.url}}>
-          <img alt={{user.term}} src={{asset-map (concat "images/users/" user.image)}}>
-        </a>
-        <h3>{{user.term}}</h3>
-        <p id="sponsorType">{{user.content}}</p>
-      </li>
-    {{/each}}
-  </ul>
+    <ul class="list-unstyled layout-grid">
+      {{#each this.pastSponsors as |sponsor|}}
+        <EsCard
+          class="col-2-large"
+          @alt=""
+          @image={{asset-map (concat "images/users/" sponsor.image)}}
+          card-link full-image vertical
+        >
+          <h3>
+            <a href={{sponsor.url}} rel="nofollow noopener" target="_blank">
+              {{sponsor.content}}
+            </a>
+          </h3>
+          <p>{{sponsor.term}}</p>
+        </EsCard>
+      {{/each}}
+    </ul>
+  </section>
 
-  <p class="thanks text-center">A special thanks to <a href="https://dribbble.com/mg">Matt Grantham</a> for design of the original Ember website.</p>
-
-</div>
+  <p class="text-center">
+    A special thanks to <a href="https://dribbble.com/mg" rel="nofollow noopener" target="_blank">Matt Grantham</a> for design of the original Ember website.
+  </p>
+</section>


### PR DESCRIPTION
This PR address the issue #443.

<img width="1680" alt="Screen Shot 2019-11-02 at 10 13 43 AM" src="https://user-images.githubusercontent.com/16869656/68073021-5830fc00-fd5a-11e9-85bb-6dfdc9ef2f08.png">
