### PR TITLE
Updated markup for Community - Meetups Getting Started

### DIFF
--- a/app/templates/community/meetups-getting-started.hbs
+++ b/app/templates/community/meetups-getting-started.hbs
@@ -1,96 +1,111 @@
-<h1>
-  Getting Your Meetup Up and Running
-</h1>
+<section class="container" aria-labelledby="getting-your-meetup-up-and-running">
+  <h1 id="getting-your-meetup-up-and-running">
+    Getting Your Meetup Up and Running
+  </h1>
 
-<p>
-  Running an Ember User Group can be challenging, but <em>really</em> rewarding: thanks so much for stepping up! We're here to help however we can.
-</p>
+  <p>
+    Running an Ember User Group can be challenging, but <em>really</em> rewarding: thanks so much for stepping up! We're here to help however we can.
+  </p>
 
-<p>
-  The three main things to do for your first user group meetup are:
+  <p>
+    The three main things to do for your first user group meetup are:
+  </p>
+
   <ol>
-    <li> Find a location to meet</li>
-    <li> Find one or two willing speakers</li>
-    <li> Find interested people</li>
+    <li>Find a location to meet</li>
+    <li>Find one or two willing speakers</li>
+    <li>Find interested people</li>
   </ol>
-</p>
 
+  <section aria-labelledby="getting-your-meetup-up-and-running-location">
+    <h2 id="getting-your-meetup-up-and-running-location">Location</h2>
 
-<h3>Location</h3>
+    <p>
+      Many software companies are willing to sponsor meetups in their conference rooms or common spaces—they're a good place to start asking. Other meetups have had good results with reserving space in restaurants, pubs and co-working spaces—just make sure they have the A/V equipment you need, a wireless network powerful enough to host your audience, and ideally ample power as well.
+    </p>
 
-<p>
-  Many software companies are willing to sponsor meetups in their conference rooms or common spaces—they're a good place to start asking. Other meetups have had good results with reserving space in restaurants, pubs and co-working spaces—just make
-  sure they have the A/V equipment you need, a wireless network powerful enough to host your audience, and ideally ample power as well.
-</p>
-<p>
-  Note that when a company donates space, they're usually expecting to receive a sponsor/host shout out on the site and in person in exchange.
-</p>
+    <p>
+      Note that when a company donates space, they're usually expecting to receive a sponsor/host shout out on the site and in person in exchange.
+    </p>
+  </section>
 
-<h3>Speakers</h3>
-<p>
-  Ideally, speakers are local and can talk about their experiences with Ember; if you're having trouble finding a speaker, let us know and we can try and set up a remote session with a member of the Core Team or other talented community member.
-</p>
-<p>
-  We definitely recommend having only one speaker per meetup from any single company, as otherwise it can start to feel kind'v corporate-sales-pitchy :p
-</p>
+  <section aria-labelledby="getting-your-meetup-up-and-running-speakers">
+    <h2 id="getting-your-meetup-up-and-running-speakers">Speakers</h2>
 
-<h3>Attendees</h3>
+    <p>
+      Ideally, speakers are local and can talk about their experiences with Ember; if you're having trouble finding a speaker, let us know and we can try and set up a remote session with a member of the Core Team or other talented community member.
+    </p>
 
-<p>
-  Hopefully, you know at least a few people who are interested in joining the user group. Most of us have been using Meetup.com to organize our groups, and it's been very effective.
-</p>
-<p>
-  Most meetups spread by word of mouth, but we'll be sure to tweet about your new group to help get you the attention and attendance you need, if you let us know.
-</p>
-<p>
-  Lastly, definitely go around to other relevant tech meetups in the area to talk about starting the new group. That's definitely your market right there.
-</p>
+    <p>
+      We definitely recommend having only one speaker per meetup from any single company, as otherwise it can start to feel kinda corporate-sales-pitchy :p
+    </p>
+  </section>
 
-<h3>Sponsorship</h3>
+  <section aria-labelledby="getting-your-meetup-up-and-running-attendees">
+    <h2 id="getting-your-meetup-up-and-running-attendees">Attendees</h2>
 
-<p>
-  Considering that many groups are able to do most of the above for free, sponsorship is not always necessary... but it can be a good way to help cover costs and extras. At our SF and Portland meetups we seek out sponsors for space and food (we find
-  that Pizza and Beer help increase attendance dramatically... no surprise there).
-</p>
-<p>
-  If you've got some local sponsors you could talk to, here are some of the other things you might want to ask them for help with:
-  <ul>
-    <li>Sponsorship of Meetup.com fees </li>
-    <li>Sponsorship of event space</li>
-    <li>Sponsorship of food, drinks and/or snacks</li>
-  </ul>
-</p>
+    <p>
+      Hopefully, you know at least a few people who are interested in joining the user group. Most of us have been using Meetup.com to organize our groups, and it's been very effective.
+    </p>
 
-<p>
-  If you're able to raise additional cash, that's even better. Some of the most successful meetup groups we've worked with over the years (not necessarily Ember) have been able to raise enough funds to periodically fly in core team members or other
-  bigwig speakers.
-</p>
-<p>
-  On a smaller scale, you could always get swag made (as in, Ember or Meetup branded swag, versus the sort of things sponsors might give you with their branding). It's not at all required, but worth thinking about and planning for if you have
-  options / funding.
-</p>
+    <p>
+      Most meetups spread by word of mouth, but we'll be sure to tweet about your new group to help get you the attention and attendance you need, if you let us know.
+    </p>
 
-<h3>Some other tidbits</h3>
-<ul>
-  <li>
-    {{! template-lint-disable attribute-indentation}}
-    For more content like this, <a href="https://medium.com/@wifelette/the-bits-n-bobs-of-starting-a-user-group-a44cfdd6bed9"> check out @wifelette's blog post</a>; much of the same content, but some new tips and tricks.
-  </li>
-  <li>
-    Check out the {{#link-to "community.meetups.assets"}}Meetup Resources{{/link-to}} page for help with art and assets for your Group.
-  </li>
-  <li>
-    We don't have a ton of funding yet on the central side of things, but we do have some Tomster stickers! Send us a mailing address once you've got your first meetup scheduled and we can send some your way.
-  </li>
-  <li>
-    There's an Ember Meetup Organizers google group that we can add you to once things start getting real (instructions on the {{#link-to "community.meetups.assets"}}Resources Page{{/link-to}}). Can be a really great resource for helping with the path forward.
-  </li>
-  <li>
-    You can add your group to the {{#link-to "community.meetups"}}>Meetups page / directory{{/link-to}} on the Ember website once you're up and running (<a href="https://github.com/emberjs/website/">just submit a PR</a>).
-  </li>
-</ul>
+    <p>
+      Lastly, definitely go around to other relevant tech meetups in the area to talk about starting the new group. That's definitely your market right there.
+    </p>
+  </section>
 
-<p>
-  Keep us in the loop—we’re excited to see Ember Meetups starting up all around the globe! And if you have questions or have other ideas for how we can help, <a href="mailto:events@tilde.io">reach out to Leah</a>. We look forward to hearing from
-  you.
-</p>
+  <section aria-labelledby="getting-your-meetup-up-and-running-sponsorship">
+    <h2 id="getting-your-meetup-up-and-running-sponsorship">Sponsorship</h2>
+
+    <p>
+      Considering that many groups are able to do most of the above for free, sponsorship is not always necessary... but it can be a good way to help cover costs and extras. At our SF and Portland meetups we seek out sponsors for space and food (we find that Pizza and Beer help increase attendance dramatically... no surprise there).
+    </p>
+
+    <p>
+      If you've got some local sponsors you could talk to, here are some of the other things you might want to ask them for help with:
+    </p>
+
+    <ul>
+      <li>Meetup.com fees</li>
+      <li>Event space</li>
+      <li>Food, drinks and snacks</li>
+    </ul>
+
+    <p>
+      If you're able to raise additional cash, that's even better. Some of the most successful meetup groups we've worked with over the years (not necessarily Ember) have been able to raise enough funds to periodically fly in core team members or other bigwig speakers.
+    </p>
+
+    <p>
+      On a smaller scale, you could always get swag made (as in, Ember or Meetup branded swag, versus the sort of things sponsors might give you with their branding). It's not at all required, but worth thinking about and planning for if you have options / funding.
+    </p>
+  </section>
+
+  <section aria-labelledby="getting-your-meetup-up-and-running-some-other-tidbits">
+    <h2 id="getting-your-meetup-up-and-running-some-other-tidbits">Some Other Tidbits</h2>
+
+    <ul>
+      <li>
+        For more content like this, check out <a href="https://medium.com/@wifelette/the-bits-n-bobs-of-starting-a-user-group-a44cfdd6bed9" rel="nofollow noopener" target="_blank">@wifelette's blog post</a>; much of the same content, but some new tips and tricks.
+      </li>
+      <li>
+        Check out {{#link-to "community.meetups.assets"}}Meetup Resources{{/link-to}} page for help with art and assets for your Group.
+      </li>
+      <li>
+        We don't have a ton of funding yet on the central side of things, but we do have some Tomster stickers! Send us a mailing address once you've got your first meetup scheduled and we can send some your way.
+      </li>
+      <li>
+        There's an Ember Meetup Organizers google group that we can add you to once things start getting real (instructions on the {{#link-to "community.meetups.assets"}}Resources Page{{/link-to}}). Can be a really great resource for helping with the path forward.
+      </li>
+      <li>
+        You can add your group to the {{#link-to "community.meetups"}}Meetups page / directory{{/link-to}} on the Ember website once you're up and running (<a href="https://github.com/emberjs/website/" rel="nofollow noopener" target="_blank">just submit a PR</a>).
+      </li>
+    </ul>
+  </section>
+
+  <p>
+    Keep us in the loop—we’re excited to see Ember Meetups starting up all around the globe! And if you have questions or have other ideas for how we can help, <a href="mailto:events@tilde.io">reach out to Leah</a>. We look forward to hearing from you.
+  </p>
+</section>


### PR DESCRIPTION
This PR addresses the issue #435 .

After update (top half):
<img width="1680" alt="screenshot after markup update (top half)" src="https://user-images.githubusercontent.com/16869656/68480738-222cc580-01fb-11ea-964b-7089abb9b812.png">

After update (bottom half):
<img width="1680" alt="screenshot after markup update (bottom half)" src="https://user-images.githubusercontent.com/16869656/68480739-222cc580-01fb-11ea-9e45-9f29450a48f7.png">
