### PR TITLE
Updated markup for Community - Meetups - Assets page

### DIFF
--- a/app/templates/community/meetups-getting-started.hbs
+++ b/app/templates/community/meetups-getting-started.hbs
@@ -91,16 +91,16 @@
         For more content like this, check out <a href="https://medium.com/@wifelette/the-bits-n-bobs-of-starting-a-user-group-a44cfdd6bed9" rel="nofollow noopener" target="_blank">@wifelette's blog post</a>; much of the same content, but some new tips and tricks.
       </li>
       <li>
-        Check out {{#link-to "community.meetups.assets"}}Meetup Resources{{/link-to}} page for help with art and assets for your Group.
+        Check out <LinkTo @route="community.meetups.assets">Meetup Resources</LinkTo> page for help with art and assets for your Group.
       </li>
       <li>
         We don't have a ton of funding yet on the central side of things, but we do have some Tomster stickers! Send us a mailing address once you've got your first meetup scheduled and we can send some your way.
       </li>
       <li>
-        There's an Ember Meetup Organizers google group that we can add you to once things start getting real (instructions on the {{#link-to "community.meetups.assets"}}Resources Page{{/link-to}}). Can be a really great resource for helping with the path forward.
+        There's an Ember Meetup Organizers google group that we can add you to once things start getting real (instructions on the <LinkTo @route="community.meetups.assets">Resources Page</LinkTo>). Can be a really great resource for helping with the path forward.
       </li>
       <li>
-        You can add your group to the {{#link-to "community.meetups"}}Meetups page / directory{{/link-to}} on the Ember website once you're up and running (<a href="https://github.com/emberjs/website/" rel="nofollow noopener" target="_blank">just submit a PR</a>).
+        You can add your group to the <LinkTo @route="community.meetups">Meetups page / directory</LinkTo> on the Ember website once you're up and running (<a href="https://github.com/emberjs/website/" rel="nofollow noopener" target="_blank">just submit a PR</a>).
       </li>
     </ul>
   </section>

--- a/app/templates/community/meetups/assets.hbs
+++ b/app/templates/community/meetups/assets.hbs
@@ -1,126 +1,191 @@
-<h1>
-  Ember Meetup Resources
-</h1>
-
-<p>
-  Running an Ember User Group can be challenging, but <em>really</em> rewarding: thanks so much for stepping up! We're here to help however we can. <a href="mailto:meetups@emberjs.com">Reach out to Leah</a> if you have questions, ideas, or anything else User Group / Meetup related.
-</p>
-
-<p>
-  If you're looking for a little help getting started, <a href="/community/meetups-getting-started">we've put together some starter tips for you</a>. Hope it's helpful!
-</p>
-
-<div>
-  <h1 class="second">
-    Assets
+<section class="container" aria-labelledby="ember-meetup-resources">
+  <h1 id="ember-meetup-resources">
+    Ember Meetup Resources
   </h1>
 
-  <h2>Branding Materials</h2>
-
-
   <p>
-    We've created user group badges and branding to help give our groups a consistent feel. You can create your own by downloading our
-    <a href="/images/meetups/Ember-Meetup-Templates.zip"> Sketch and Illustrator templates (ZIP)</a>.
+    Running an Ember User Group can be challenging, but <em>really</em> rewarding: thanks so much for stepping up! We're here to help however we can. <a href="mailto:meetups@emberjs.com">Reach out to Leah</a> if you have questions, ideas, or anything else User Group / Meetup related.
   </p>
 
-
   <p>
-    If you're using <a href="//meetup.com" target="__blank">Meetup</a> to manage your group, you can also use our header image for your group's pages:
-  </p>
-  <a href="/images/meetups/ember-meetup-header.jpg" target="-_blank"><img class="meetups-header" src="/images/meetups/ember-meetup-header.jpg" alt="Ember Meetup Header"></a>
-
-
-  <h2>Logos</h2>
-  <img alt="Example meetups logo" class="example-meetups-logo" src="/images/meetups/ember-meetup-logo-san-francisco.png" srcset="/images/meetups/ember-meetup-logo-san-francisco.png 1x, /images/meetups/ember-meetup-logo-san-francisco@2x.png 2x">
-
-  <p>
-    Our <a href="/images/meetups/Ember-Meetup-Templates.zip">logo design templates (ZIP)</a> allow you to create a meetup logo for your city in a range of formats. For usage instructions, see our <a href="/images/brand/Ember-Brand-Guidelines.pdf">brand guidelines (PDF)</a>.
-  </p>
-  <p>
-    The primary Ember logo may be used the terms covered on our <a href="/branding">branding page</a>. In general, manipulations of any sort are not allowed. Please <a href="mailto:leah@emberjs.com">email us</a> with any questions.
+    If you're looking for a little help getting started, <LinkTo @route="community.meetups-getting-started">we've put together some starter tips for you</LinkTo>. Hope it's helpful!
   </p>
 
-  <ul class="inline_list">
-    <li><a href="/images/logos/ember-logo.ai">Logo in Illustrator format</a></li>
-    <li><a href="/images/logos/ember-logo.png">Logo in PNG format, transparent background</a></li>
-    <li><a href="/images/brand/logos-ember.zip">All Ember logos (ZIP)</a></li>
-  </ul>
+  <section aria-labelledby="ember-meetup-resources-assets">
+    <h2 id="ember-meetup-resources-assets">
+      Assets
+    </h2>
 
-  <h2>Stickers</h2>
+    <section aria-labelledby="ember-meetup-resources-assets-branding-materials">
+      <h3 id="ember-meetup-resources-assets-branding-materials">
+        Branding Materials
+      </h3>
 
-  <p>
-    The Ember Core Team has a small stash of Ember stickers donated by the folks at <a href="http://tilde.io">Tilde</a>. These are distributed as requested while in stock. If you'd like to print your own Ember stickers, here are the files you'll need for the canonical ones.
-  </p>
+      <p>
+        We've created user group badges and branding to help give our groups a consistent feel. You can create your own by downloading our <a href="/images/meetups/Ember-Meetup-Templates.zip">Sketch and Illustrator templates (ZIP)</a>.
+      </p>
 
-  <ul class="inline_list">
-    <li><a href="/images/stickers/ember-sticker.ai">Ember Logo Stickers</a>, best printed die-cut at 3.0" x 1.25"</li>
-    <li><a href="/images/stickers/tomster-sticker.ai">Ember Mascot Stickers</a>, best printed die-cut at 3" x 3"</li>
-  </ul>
+      <p>
+        If you're using <a href="https://www.meetup.com/" rel="nofollow noopener" target="_blank">Meetup</a> to manage your group, you can also <a href="/images/meetups/ember-meetup-header.jpg">download our header image</a> for your group's pages:
+      </p>
 
-  <p>
-    We recommend printing your stickers with <a href="http://www.stickermule.com/unlock?ref_id=3368978601">StickerMule</a>, who are long time supporters of Open Source. The link here will also get you $10 off your first order.
-  </p>
+      <div class="layout-grid">
+        <img
+          class="col-3-large"
+          src="/images/meetups/ember-meetup-header.jpg"
+          alt="Header image for an Ember Meetup"
+        >
+      </div>
+    </section>
 
-  <div>
-    <h2 class="second">
-      Custom Tomsters and Zoeys
+    <section aria-labelledby="ember-meetup-resources-assets-logos">
+      <h3 id="ember-meetup-resources-assets-logos">
+        Logos
+      </h3>
+
+      <p>
+        Our <a href="/images/meetups/Ember-Meetup-Templates.zip">logo design templates (ZIP)</a> allow you to create a meetup logo for your city in a range of formats. For usage instructions, see our <a href="/images/brand/Ember-Brand-Guidelines.pdf">brand guidelines (PDF)</a>.
+      </p>
+
+      <div class="layout-grid">
+        <img
+          class="col-3-large"
+          src="/images/meetups/ember-meetup-logo-san-francisco.png"
+          srcset="/images/meetups/ember-meetup-logo-san-francisco.png 1x, /images/meetups/ember-meetup-logo-san-francisco@2x.png 2x"
+          alt="Ember Meetup logo for San Francisco"
+        >
+      </div>
+
+      <p>
+        The primary Ember logo may be used the terms covered on our <LinkTo @route="logos">Branding</LinkTo> page. In general, manipulations of any sort are not allowed. Please <a href="mailto:leah@emberjs.com">email us</a> with any questions.
+      </p>
+
+      <ul>
+        <li><a href="/images/logos/ember-logo.ai">Logo in Illustrator format</a></li>
+        <li><a href="/images/logos/ember-logo.png">Logo in PNG format, transparent background</a></li>
+        <li><a href="/images/brand/logos-ember.zip">All Ember logos (ZIP)</a></li>
+      </ul>
+    </section>
+
+    <section aria-labelledby="ember-meetup-resources-assets-stickers">
+      <h3 id="ember-meetup-resources-assets-stickers">
+        Stickers
+      </h3>
+
+      <p>
+        The Ember Core Team has a small stash of Ember stickers donated by the folks at <a href="https://www.tilde.io/" rel="nofollow noopener" target="_blank">Tilde</a>. These are distributed as requested while in stock. If you'd like to print your own Ember stickers, here are the files you'll need for the canonical ones.
+      </p>
+
+      <ul>
+        <li><a href="/images/stickers/ember-sticker.ai">Ember Logo Stickers</a>, best printed die-cut at 3" x 1.25"</li>
+        <li><a href="/images/stickers/tomster-sticker.ai">Ember Mascot Stickers</a>, best printed die-cut at 3" x 3"</li>
+      </ul>
+
+      <p>
+        We recommend printing your stickers with <a href="https://www.stickermule.com/unlock?ref_id=3368978601" rel="nofollow noopener" target="_blank">StickerMule</a>, who are long time supporters of open source. The link here will also get you $10 off your first order.
+      </p>
+    </section>
+
+    <section aria-labelledby="ember-meetup-resources-assets-custom-tomsters-and-zoeys">
+      <h3 id="ember-meetup-resources-assets-custom-tomsters-and-zoeys">
+        Custom Tomsters and Zoeys
+      </h3>
+
+      <p>
+        You may have noticed that some user groups (Salt Lake City, Munich, London, etc.) have their own custom Tomster and Zoey variants. These have been commissioned and licensed by the groups. They paid a small commission fee to have the character designed by one of the official designers, and we granted them a license to use that variant for non-commercial user group related purposes.
+      </p>
+
+      <ul class="list-unstyled layout-grid">
+        <EsCard
+          class="col-2-large text-center"
+          @alt=""
+          @image="/images/community/tomsters/Ember-Munich-Half-sm.png"
+          card-link vertical
+        >
+          <h4>
+            <a href="https://www.meetup.com/Ember-js-Munich/" rel="nofollow noopener" target="_blank">
+              Ember Munich
+            </a>
+          </h4>
+        </EsCard>
+
+        <EsCard
+          class="col-2-large text-center"
+          @alt=""
+          @image="/images/community/tomsters/Ember-Austin-Zoey-Half-sm.png"
+          card-link vertical
+        >
+          <h4>
+            <a href="https://www.meetup.com/Ember-ATX/" rel="nofollow noopener" target="_blank">
+              Ember Austin
+            </a>
+          </h4>
+        </EsCard>
+
+        <EsCard
+          class="col-2-large text-center"
+          @alt=""
+          @image="/images/community/tomsters/Ember-Vancouver-Half-sm.png"
+          card-link vertical
+        >
+          <h4>
+            <a href="https://www.meetup.com/Vancouver-Ember-js/" rel="nofollow noopener" target="_blank">
+              Ember Vancouver
+            </a>
+          </h4>
+        </EsCard>
+      </ul>
+
+      <p>
+        Thankfully, our designers love Ember and therefore give us ridiculously fair deals. Pricing ranges from $80 to $300, depending on the extent of the request. On average, most user groups spend $200.
+      </p>
+
+      <p>
+        If you're interested in commissioning a Meetup/User Group Tomster or Zoey, <LinkTo @route="mascots.commission">reach out to us with details</LinkTo>.
+      </p>
+    </section>
+  </section>
+
+  <section aria-labelledby="ember-meetup-resources-recording-your-meetup">
+    <h2 id="ember-meetup-resources-recording-your-meetup">
+      Recording Your Meetup
     </h2>
 
     <p>
-      You may have noticed that some user groups (Salt Lake City, Munich, London, etc.) have their own custom Tomster and/or Zoey variants. These have been commissioned and licensed by the groups; they paid a small commission fee to have the character designed by one of the official designers, and we granted them a license to use that variant for non-commercial user group related purposes.
-    </p>
-
-    <p class="tomsterVar">
-      <a href="http://www.meetup.com/Ember-js-Munich/">
-        <img alt="Ember Munich meetup" width="180px" src="/images/community/tomsters/Ember-Munich-Half-sm.png">
-      </a>
-      <a href="http://www.meetup.com/Ember-ATX/">
-        <img alt="Ember Austin meetup" width="180px" src="/images/community/tomsters/Ember-Austin-Zoey-Half-sm.png">
-      </a>
-      <a href="http://www.meetup.com/Vancouver-Ember-js/">
-        <img alt="Ember Vancouver meetup" width="180px" src="/images/community/tomsters/Ember-Vancouver-Half-sm.png">
-      </a>
+      Many Ember Meetup organizers have done the community a tremendous service by having their meetups recorded. In some cases, groups are able to find sponsors, and in others, sponsors pick up either the expense and/or the labor.
     </p>
 
     <p>
-      Thankfully, our designers love Ember and therefore give us ridiculously fair deals. Pricing ranges from $80 to $300, depending on the extent of the request. On average, most user groups spend $200.
+      The London group was the first to roll their own, with Portland and other cities to follow. Overall, one-time equipment cost in USD was approximately $350, plus two HDMI cords and the use of an iPhone or Tablet.
     </p>
+
     <p>
-      If you're interested in commissioning a Meetup/User Group Tomster or Zoey, <a href="../tomster/commission/">reach out to us with details</a>.
+      If you're interested in recording your meetups on your own, here are the items some of those groups have had success with:
     </p>
-  </div>
 
-  <h1>Recording Your Meetup</h1>
-
-  <p>
-    Many Ember Meetup organizers have done the community a tremendous service by having their meetups recorded. In some cases groups are able to find sponsors, and in others, sponsors pick up either the expense and/or the labor.
-  </p>
-  <p>
-    The London group was the first to roll their own, with Portland and other cities to follow. Overall one-time equipment spend in USD was approximately $350, plus two HDMI cords and the use of an iPhone or Tablet.
-  </p>
-  <p>
-    If you're interested in recording your meetups on your own, here are the items some of those groups have had success with:
-  </p>
-  <ul>
-    <li>
-      <a href="https://www.amazon.com/AmazonBasics-60-Inch-Lightweight-Tripod-Bag/dp/B005KP473Q/ref=sr_1_2?ie=UTF8&qid=1475263846&sr=8-2&keywords=tripod">Lightweight tripod</a> with adjustable-height legs, rubber feet and great maneuverability.
-    </li>
-    <li>
-      <a href="https://www.amazon.com/gp/product/B009GHYLKS/ref=oh_aui_search_detailpage?ie=UTF8&psc=1">Phone-sized mount</a> so your phone can hook into the tripod.
-    </li>
-    <li>
-      <a href="https://www.amazon.com/gp/product/B00MIQ40JQ/ref=oh_aui_detailpage_o06_s00?ie=UTF8&psc=1">Game Capture device</a> for recording the presenter's slides.
-    </li>
-    <li>
-      <a href="https://www.amazon.com/gp/product/B003QKBVYK/ref=oh_aui_detailpage_o06_s00?ie=UTF8&psc=1">Voice recorder</a> so you're recording the speaker's audio separately, and not using the not-too-great cell phone video audio.
-    </li>
-    <li>
-      <a href="https://www.amazon.com/gp/product/B00KMILKGS/ref=oh_aui_detailpage_o06_s00?ie=UTF8&psc=1">Lavalier Mic</a> that plugs into the voice recorder, to allow your speakers maximum maneuverability.
-    </li>
-  </ul>
-  <p>
-    To make this setup work, you'll need a laptop, in <em>addition</em> to the presenter's laptop. The basic process is:
     <ul>
+      <li>
+        <a href="https://www.amazon.com/gp/product/B005KP473Q/" rel="nofollow noopener" target="_blank">Lightweight tripod</a> with adjustable-height legs, rubber feet and great maneuverability
+      </li>
+      <li>
+        <a href="https://www.amazon.com/gp/product/B009GHYLKS/" rel="nofollow noopener" target="_blank">Phone-sized mount</a> so your phone can hook into the tripod
+      </li>
+      <li>
+        <a href="https://www.amazon.com/gp/product/B00MIQ40JQ/" rel="nofollow noopener" target="_blank">Game capture device</a> for recording the presenter's slides
+      </li>
+      <li>
+        <a href="https://www.amazon.com/gp/product/B003QKBVYK/" rel="nofollow noopener" target="_blank">Voice recorder</a> so you're recording the speaker's audio separately, and not using the not-too-great cell phone video audio
+      </li>
+      <li>
+        <a href="https://www.amazon.com/gp/product/B00KMILKGS/" rel="nofollow noopener" target="_blank">Lavalier mic</a> that plugs into the voice recorder, to allow your speakers maximum maneuverability
+      </li>
+    </ul>
+
+    <p>
+      To make this setup work, you'll need a laptop, in addition to the presenter's laptop. The basic process is:
+    </p>
+
+    <ol>
       <li>
         The presenter's laptop gets plugged via HDMI into the Video Capture device (HDMI In).
       </li>
@@ -142,11 +207,16 @@
       <li>
         After the event, download all three files onto one laptop, and use something like Screenflow to sync them up and produce your video. Alternatively, if you have <em>some</em> sponsorship, you can find a local producer or videographer to do this work for you for a few hundred dollars, depending on the volume of content.
       </li>
-    </ul>
-  </p>
+    </ol>
+  </section>
 
-  <h1>Organizers Network</h1>
-  <p>
-    There's a great (not-so-secret) channel in the <a href="https://discordapp.com/invite/zT3asNS">Ember Community Discord</a> for organizers. Request to be added to the <dfn>meetup-organizer</dfn> role in #discord-server-admin so that you can join us!
-  </p>
-</div>
+  <section aria-labelledby="ember-meetup-resources-organizers-network">
+    <h2 id="ember-meetup-resources-organizers-network">
+      Organizers Network
+    </h2>
+
+    <p>
+      There's a great (not-so-secret) channel in the <a href="https://discordapp.com/invite/zT3asNS" rel="nofollow noopener" target="_blank">Ember Community Discord</a> for organizers. Request to be added to the <dfn>meetup-organizer</dfn> role in #discord-server-admin so that you can join us!
+    </p>
+  </section>
+</section>


### PR DESCRIPTION
This PR addresses the issue #434 .

Screenshot after change (1):
<img width="1680" alt="" src="https://user-images.githubusercontent.com/16869656/68550531-34f4f500-03c9-11ea-91c1-f2d041997b68.png">

Screenshot after change (2):
<img width="1680" alt="" src="https://user-images.githubusercontent.com/16869656/68550532-34f4f500-03c9-11ea-962c-086c8afe38c1.png">

Screenshot after change (3):
<img width="1680" alt="" src="https://user-images.githubusercontent.com/16869656/68550533-34f4f500-03c9-11ea-9657-493e313a056a.png">
