### PR TITLE
Updated markup for Learn - Examples page

### DIFF
--- a/app/templates/learn/examples.hbs
+++ b/app/templates/learn/examples.hbs
@@ -1,34 +1,45 @@
-<h1 id="examples">Examples</h1>
+<section class="container" aria-labelledby="learning-emberjs-examples">
+  <h1 id="learning-emberjs-examples">Examples</h1>
 
-<p>In this section you will find applications that are maintained by the Ember.js teams with the help of contributors. While software is always a work in progress, the goal is to showcase patterns and solutions applied in real-world applications.</p>
-<p>Whether you're simply interested in checking out how some feature is implemented, or you're looking to contribute, one of these projects might pique your interest!</p>
+  <p>In this section, you will find applications that are maintained by the Ember.js teams with the help of contributors. While software is always a work in progress, the goal is to showcase patterns and solutions applied in real-world applications.</p>
 
-<div class="showcase">
-  {{#each model as |showcase|}}
-    <div class="showcase--item">
-      <div class="showcase--screenshot">
-        <img
-          class="showcase--image"
-          src={{asset-map (concat "images/showcase/" showcase.image.src)}}
-          alt={{showcase.image.alt}}
-        >
-      </div>
-      <div class="showcase--description">
-        <h3>
-          <a href={{showcase.demo}}>{{showcase.name}}<i class="icon-link-ext"></i></a>
-        </h3>
+  <p>Whether you're simply interested in checking out how some feature is implemented, or you're looking to contribute, one of these projects might pique your interest!</p>
 
-        <p>Repository: <a href={{showcase.repository}}>{{showcase.repository}}</a></p>
+  <ul class="list-unstyled layout-grid">
+    {{#each this.model as |showcase|}}
+      <EsCard
+        class="col-3-large"
+        @alt=""
+        @image={{asset-map (concat "images/showcase/" showcase.image.src)}}
+        full-image vertical
+      >
+        <h2>{{showcase.name}}</h2>
 
-        <p>
-          {{showcase.description}}
-          <ul>
-            {{#each showcase.features as |feature|}}
-              <li>{{html-safe feature}}</li>
-            {{/each}}
-          </ul>
-        </p>
-      </div>
-    </div>
-  {{/each}}
-</div>
+        <p>{{showcase.description}}</p>
+
+        <h3>Features</h3>
+
+        <ul>
+          {{#each showcase.features as |feature|}}
+            <li>{{html-safe feature}}</li>
+          {{/each}}
+        </ul>
+
+        <h3>External Links</h3>
+
+        <ul class="list-unstyled">
+          <li>
+            <a href={{showcase.demo}} rel="nofollow noopener" target="_blank">
+              Visit website
+            </a>
+          </li>
+          <li>
+            <a href={{showcase.repository}} rel="nofollow noopener" target="_blank">
+              Visit repository
+            </a>
+          </li>
+        </ul>
+      </EsCard>
+    {{/each}}
+  </ul>
+</section>

--- a/app/templates/learn/examples.hbs
+++ b/app/templates/learn/examples.hbs
@@ -15,9 +15,9 @@
       >
         <h2>{{showcase.name}}</h2>
 
-        <p>{{showcase.description}}</p>
+        <h3>Description</h3>
 
-        <h3>Features</h3>
+        {{html-safe showcase.html}}
 
         <ul>
           {{#each showcase.features as |feature|}}


### PR DESCRIPTION
This PR addresses the issue #439 . Here, I used `<EsCard>` component to represent the information.

If we want to make the webpage look more like what it is now, we might add a grid layout around each example, with 2 columns for the image and 4 columns for the text. However, I thought this might cause the text to be unreadable at mobile resolution, which is what happens currently. I have not tried this approach to see whether the issue would actually occur with the new styleguide.

Desktop (before):
<img width="1680" alt="" src="https://user-images.githubusercontent.com/16869656/68682436-c16af900-052a-11ea-8e0a-dc228275f8fe.png">

Desktop (after):
<img width="1680" alt="" src="https://user-images.githubusercontent.com/16869656/68682443-c334bc80-052a-11ea-8b74-5a5d1c7b26d5.png">

Mobile (before):
<img width="480" alt="" src="https://user-images.githubusercontent.com/16869656/68682451-c465e980-052a-11ea-9ebd-c1bece447e9c.png">

Mobile (after):
<img width="480" alt="" src="https://user-images.githubusercontent.com/16869656/68682456-c62fad00-052a-11ea-8773-abed63919b3a.png">
