### PR TITLE
fix axe warnings

### DIFF
--- a/app/styles/components/addon-tabs.css
+++ b/app/styles/components/addon-tabs.css
@@ -1,6 +1,5 @@
 .addon-tabs {
   background: linear-gradient(0deg, rgba(52,55,62,1) 0%, rgba(66,69,77,1) 100%);
-  background: rgb(52,55,62);
   border-radius: 15px;
   box-shadow: 0px 5px 15px -10px rgba(0,0,0,0.75);
   width: 100%;
@@ -19,12 +18,12 @@
   height: 50px;
   margin: 0;
   margin-left: -1px;
-  padding: 0 10px;
+  padding: 0 var(--spacing-2);
   text-align: left;
 }
 
 .addon-tabs--tab.active-tab {
-  background-color: var(--color-button-bg);
+  background-color: var(--color-brand-hc-dark);
   color: var(--color-button-text);
 }
 

--- a/app/templates/components/addon-tabs.hbs
+++ b/app/templates/components/addon-tabs.hbs
@@ -5,7 +5,7 @@
       @tabId={{0}}
       @onClick={{action (mut this.currentTab) 0}}
     >
-      ember-cli-sass
+      SASS
     </AddonTabs::Tab>
     <AddonTabs::Tab
       @currentTab={{this.currentTab}}
@@ -19,14 +19,14 @@
       @tabId={{2}}
       @onClick={{action (mut this.currentTab) 2}}
     >
-      Percy
+      Auth
     </AddonTabs::Tab>
     <AddonTabs::Tab
       @currentTab={{this.currentTab}}
       @tabId={{3}}
       @onClick={{action (mut this.currentTab) 3}}
     >
-      ember-cli-deploy
+      Deploy
     </AddonTabs::Tab>
   </div>
 

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -171,7 +171,7 @@
       </h3>
     </div>
 
-    <div class="grid lg:grid-2 list-unstyled">
+    <ul class="grid lg:grid-2 list-unstyled">
       <EsCard class="lg:col-3" @image="/images/icons/discuss-logo.svg" card-link>
         <h3>
           <a href="http://discuss.emberjs.com">Discussion Forum</a>
@@ -184,7 +184,7 @@
         </h3>
         <p>Join our real-time chat server to connect with other developers and get answers.</p>
       </EsCard>
-    </div>
+    </ul>
 
     <p class="lg:col-4 lg:start-2 my-3 text-center">
       Beyond our core online channels, you can dig deeper with these learning resources from the
@@ -226,7 +226,7 @@
         </div>
       </div>
     </div>
-    <div class="grid lg:grid-2 mt-4 list-unstyled">
+    <ul class="grid lg:grid-2 mt-4 list-unstyled">
       <EsCard @image="/images/home/guides.svg" class="bg-dark" card-link>
         <h3>
           <a href="https://guides.emberjs.com" class="text-md">Read the Guides</a>
@@ -240,6 +240,6 @@
         </h3>
         <p>Find out about the newest releases and latest work happening in the ecosystem by visiting the official Ember Blog.</p>
       </EsCard>
-    </div>
+    </ul>
   </div>
 </section>


### PR DESCRIPTION
This now fixes all the remaining Axe warnings on the landing page (one more will be fixed with https://github.com/ember-learn/ember-styleguide/pull/278)

If you run Axe after this is merged it will show a bunch of "cannot determine contrast ratio because of background image" 🤔 is there any way that we can disable this? Most of our background images are just there for frills that don't cross most of the text so if we could get Axe to ignore the background images completely then it would be more useful in this case