### PR TITLE
fix title metadata

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,13 +5,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="description" content="Ember.js helps developers be more productive out of the box. Designed with developer ergonomics in mind, its friendly APIs help you get your job done—fast.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property="st:title" content="Ember.js: A framework for ambitious web developers" />
-    <meta property="og:title" content="Ember.js: A framework for ambitious web developers" />
     <meta property="og:description" content="Ember.js helps developers be more productive out of the box. Designed with developer ergonomics in mind, its friendly APIs help you get your job done—fast." />
     <meta property="og:image" content="/images/tomster-sm.png" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@emberjs" />
-    <meta name="twitter:title" content="A framework for ambitious web developers"/>
     <meta name="google-site-verification" content="N9yOP2jCLcZBMHUet-JRqU2jnLVPeLDaePpkCqXGQXM" />
     <meta name="twitter:image" content="/images/tomster-twitter-card.png" />
 

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,1 +1,4 @@
 <title>{{model.title}}</title>
+<meta property="st:title" content={{model.title}}>
+<meta property="og:title" content={{model.title}}>
+<meta name="twitter:title" content={{model.title}}>


### PR DESCRIPTION
This is just an extension of https://github.com/ember-learn/ember-website/pull/379 that applies the same title information to the twitter and OG metadata fields

As I mentioned in https://github.com/ember-learn/ember-website/pull/379#issuecomment-523373148 we need to have a more full review of metadata and that can be done after the redesign is released.

This closes https://github.com/ember-learn/ember-website/issues/537 and I have made sure that titles are updating as you navigate through the app 👍  