### PR TITLE
Add a z-index to the Leaflet map wrapper element

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -17,6 +17,7 @@
 
 .leaflet-container {
    height: 400px;
+   z-index: 0;
  }
 
 .align-middle {


### PR DESCRIPTION
Leaflet uses z-index values for it's inner dom structure which makes them apear above the navigation bar dropdowns.

Closes #569 