### PR TITLE
Make the video whitespace consistent

### DIFF
--- a/app/templates/community/index.hbs
+++ b/app/templates/community/index.hbs
@@ -110,7 +110,7 @@
 </div>
 
 <div class="container">
-  <div class="embed-video mt-5">
+  <div class="embed-video">
     <iframe width="854" height="480" src="https://www.youtube.com/embed/rY5D38RQoEg?rel=0" frameborder="0" allowfullscreen></iframe>
   </div>
 </div>


### PR DESCRIPTION
I noticed the [video on the community page](https://deploy-preview-361--ember-website.netlify.com/community) had inconsistent whitespace which I assume is a remnant from the previous version.

I also noticed the images are a bit blurry do to them being upscaled and that especially noticable on mobile devices. Are there any plans of them being replaced with svg versions?

If not, I personally wouldn't upscale them and just center the image on mobile, and left / right align them on larger devices (depending on how they are positioned next to the text). Thoughts? @MelSumner @mansona 

PS. I know things like this is very nitpicky so let me know if it shouldn't be reported :smile: 