### PR TITLE
🐛 Update releases page for 3.16

### DIFF
--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -12,7 +12,7 @@ finalVersion: 3.17.0
 channel: beta
 cycleEstimatedFinishDate: 2020-03-25
 date: 2020-02-18
-nextDate: 2020-03-25
+nextDate: 2020-03-02
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -5,14 +5,14 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.15.0
-lastRelease: 3.16.0-beta.1
-futureVersion: 3.16.0-beta.1
-finalVersion: 3.16.0
+initialVersion: 3.16.0
+lastRelease: 3.17.0-beta.5
+futureVersion: 3.17.0-beta.5
+finalVersion: 3.17.0
 channel: beta
-cycleEstimatedFinishDate: 2020-01-20
-date: 2019-12-10
-nextDate: 2019-12-16
+cycleEstimatedFinishDate: 2020-03-25
+date: 2020-02-18
+nextDate: 2020-03-25
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -10,7 +10,7 @@ lastRelease: 3.17.0-beta.5
 futureVersion: 3.17.0-beta.5
 finalVersion: 3.17.0
 channel: beta
-cycleEstimatedFinishDate: 2020-03-25
+cycleEstimatedFinishDate: 2020-03-02
 date: 2020-02-18
 nextDate: 2020-03-02
 changelogPath: CHANGELOG.md

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -6,7 +6,7 @@ filter:
   - /ember-template-compiler/
 repo: emberjs/ember.js
 initialVersion: 3.16.0
-initialReleaseDate: 2020-02-12
+initialReleaseDate: 2020-01-20
 lastRelease: 3.16.3
 futureVersion: 3.16.4
 channel: release

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.15.0
-initialReleaseDate: 2019-10-12
-lastRelease: 3.15.0
-futureVersion: 3.15.1
+initialVersion: 3.16.0
+initialReleaseDate: 2020-02-12
+lastRelease: 3.16.3
+futureVersion: 3.16.4
 channel: release
-date: 2019-12-10
+date: 2020-02-18
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -8,7 +8,7 @@ lastRelease: 3.17.0-beta.0
 futureVersion: 3.17.0-beta.1
 finalVersion: 3.17.0
 channel: beta
-date: 2020-02-18
+date: 2020-01-25
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ignoreFiles:

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -4,11 +4,11 @@ baseFileName: ember-data
 filter:
  - /ember-data\./
 repo: emberjs/data
-lastRelease: 3.16.0-beta.0
-futureVersion: 3.16.0-beta.0
-finalVersion: 3.16.0
+lastRelease: 3.17.0-beta.0
+futureVersion: 3.17.0-beta.1
+finalVersion: 3.17.0
 channel: beta
-date: 2019-12-20
+date: 2020-02-18
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ignoreFiles:

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -5,7 +5,7 @@ filter:
   - /ember-data\./
 repo: emberjs/data
 initialVersion: 3.16.0
-initialReleaseDate: 2020-02-12
+initialReleaseDate: 2020-01-25
 lastRelease: 3.16.0
 futureVersion: 3.17.0
 channel: release

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -4,12 +4,12 @@ baseFileName: ember-data
 filter:
   - /ember-data\./
 repo: emberjs/data
-initialVersion: 3.15.0
-initialReleaseDate: 2019-12-18
-lastRelease: 3.15.0
-futureVersion: 3.16.0
+initialVersion: 3.16.0
+initialReleaseDate: 2020-02-12
+lastRelease: 3.16.0
+futureVersion: 3.17.0
 channel: release
-date: 2019-12-18
+date: 2020-02-18
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ---


### PR DESCRIPTION
Followed: https://github.com/ember-learn/ember-website/pull/490
- Assumed date was today, Feb 18
- `nextDate` = Mar 25, 6wk from initialReleaseDate
- `initialReleaseDate` = Feb 12, date of blog post
- For version #s, went to GitHub repo links

Resolves: https://github.com/ember-learn/ember-website/issues/568

Let me know if needs edits or feel free to commit directly to the branch!