### PR TITLE
Redesign/install ember truth helpers

### DIFF
--- a/app/helpers/eq.js
+++ b/app/helpers/eq.js
@@ -1,7 +1,0 @@
-import { helper } from '@ember/component/helper';
-
-export function eq(params) {
-  return params[0] === params[1];
-}
-
-export default helper(eq);

--- a/app/helpers/gte.js
+++ b/app/helpers/gte.js
@@ -1,7 +1,0 @@
-import { helper } from '@ember/component/helper';
-
- export function gte([base, comparison]) {
-  return base >= comparison;
-}
-
- export default helper(gte);

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "ember-styleguide": "^4.0.0-10",
     "ember-template-lint": "^1.3.0",
     "ember-tether": "^1.0.0",
+    "ember-truth-helpers": "^2.1.0",
     "eslint-plugin-ember": "^6.2.0",
     "eslint-plugin-node": "^9.0.1",
     "highcharts": "^7.1.2",


### PR DESCRIPTION
I need a `not` helper in #585, but I noticed the app doesn't have ember-truth-helpers installed and custom `eq` and `gte` helpers are defined. Is there a specific reason for that?