### PR TITLE
Redesign/addon tabs styling improvements

### DIFF
--- a/app/styles/components/addon-tabs.css
+++ b/app/styles/components/addon-tabs.css
@@ -15,6 +15,7 @@
   align-items: center;
   background: none;
   border-color: #54565E;
+  border-style: solid;
   border-width: 1px;
   color: var(--color-gray-300);
   display: flex;

--- a/app/styles/components/addon-tabs.css
+++ b/app/styles/components/addon-tabs.css
@@ -23,6 +23,7 @@
   justify-content: center;
   margin: 0;
   margin-left: -1px;
+  padding: 0 var(--spacing-1);
 }
 
 


### PR DESCRIPTION
I noticed some weird behaviour in Firefox when clicking the AddonTabs buttons. The text was shifting 1 pixel, and the borders changed color. The borders also had a different color in Chrome.