### PR TITLE
Remove extra space in a word on the homepage

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -122,7 +122,7 @@
     <div class="lg:col-3">
       <h3 class="text-lg">Meet Addons: high-quality, curated npm packages that supercharge your app</h3>
       <p>While Ember CLI makes it easy to add any third-party node module, Ember Addons provide capabilities that go way beyond your typical npm package.</p>
-      <p>By hooking into Ember CLI's standardized tooling, Addons can modify your app's build steps, h elp you out with deployment, inline images and more.</p>
+      <p>By hooking into Ember CLI's standardized tooling, Addons can modify your app's build steps, help you out with deployment, inline images and more.</p>
       <p>With all this power wrapped up into a single install command, and no additional build tool or configuration required, you'll wonder how you could ever go back to wiring up dependencies on your own again.</p>
     </div>
 


### PR DESCRIPTION
Super minor thing, just noticed an extra space in the word "help" on the new homepage.