### PR TITLE
Fix Ember Weekend and Ember Weekly Homepage Links

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -206,7 +206,7 @@
         <h4 class="text-md">Podcasts</h4>
 
         <ul class="list-unstyled">
-          <li><a href="https://emberweekend.com/episodes">Ember Weekly</a></li>
+          <li><a href="https://emberweekend.com/episodes">Ember Weekend</a></li>
           <li><a href="https://embermap.com/podcast">Ember Map Podcast</a></li>
         </ul>
       </EsCard>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -220,6 +220,7 @@
         <ul class="list-unstyled">
           <li><a href="https://www.balinterdi.com/rock-and-roll-with-emberjs/" title="a book that helps you learn Ember">Rock and Roll with Ember.js</a></li>
           <li><a href="https://www.pzuraq.com/tag/octane/" title="a blog series by pzuraq">Octane: the blog series</a></li>
+          <li><a href="https://www.emberweekly.com/" title="latest Ember news and articles">Ember Weekly</a></li>
         </ul>
       </EsCard>
 


### PR DESCRIPTION
On the homepage currently the "Ember Weekly" link (in the podcast section?) is linking to Ember Weekend and there is no link to Ember Weekly proper. This PR fixes the podcast link and adds Ember Weekly as to the Books and Blogs section since I thought that is the closest approximation as a reading resource