### PR TITLE
Updated Releases - LTS page

### DIFF
--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -9,7 +9,7 @@
   <h2>What is an LTS release?</h2>
 
   <p>
-    LTS versions receive bugfixes for 30 weeks and security updates for 54 weeks.
+    LTS versions receive bugfixes for 36 weeks and security updates for 54 weeks.
     An LTS release is the best version to use if you won't be updating your app frequently,
     but want to help your app stay secure and working smoothly.
     Another reason to use an LTS is if you have a very large, complex app,
@@ -22,88 +22,44 @@
     developers.
   </p>
 
-  <h2>LTS support schedule</h2>
+  <h2>LTS schedule</h2>
 
-  <table class="lts-schedule table">
+  <p>
+    Ember currently supports these LTS versions.
+  </p>
+
+  <table>
     <thead>
       <tr>
-        <td>LTS Version</td>
-        <td>Released</td>
-        <td>Bugfixes until</td>
-        <td>Security patches until</td>
+        <th>LTS Version</th>
+        <th>Released</th>
+        <th>Bugfixes until</th>
+        <th>Security patches until</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td>
-          3.16
-        </td>
-        <td>
-          Feb 2020
-        </td>
-        <td>
-          Sep 2020
-        </td>
-        <td>
-          Feb 2021
-        </td>
+        <td>3.16</td>
+        <td>Jan 20, 2020</td>
+        <td>Sep 2020</td>
+        <td>Feb 2021</td>
       </tr>
       <tr>
-        <td>
-          3.12
-        </td>
-        <td>
-          Aug 2019
-        </td>
-        <td>
-          Mar 2020
-        </td>
-        <td>
-          Aug 2020
-        </td>
+        <td>3.12</td>
+        <td>Aug 5, 2019</td>
+        <td>Apr 2020</td>
+        <td>Aug 2020</td>
       </tr>
       <tr>
-        <td>
-          3.8
-        </td>
-        <td>
-          Feb 2019
-        </td>
-        <td>
-          Sep 2019
-        </td>
-        <td>
-          Feb 2020
-        </td>
-      </tr>
-      <tr>
-        <td>
-          3.4
-        </td>
-        <td>
-          Oct 2018
-        </td>
-        <td>
-          May 2019
-        </td>
-        <td>
-          Oct 2019
-        </td>
-      </tr>
-      <tr>
-        <td>
-          2.18
-        </td>
-        <td>
-          Feb 2018
-        </td>
-        <td>
-          Sept 2018
-        </td>
-        <td>
-          Feb 2019
-        </td>
+        <td>3.8</td>
+        <td>Feb 18, 2019</td>
+        <td>Oct 2019</td>
+        <td>Mar 2020</td>
       </tr>
     </tbody>
   </table>
+
+  <p>
+    These LTS versions are no longer maintained: 3.4 (Jan 2019), 2.18 (Feb 2018), 2.16 (Feb 2018), 2.12 (Apr 2017), 2.8 (Nov 2016), and 2.4 (Apr 2016). Their last minor release dates are shown in parentheses.
+  </p>
 {{/project-listing}}

--- a/data/project/ember/lts.md
+++ b/data/project/ember/lts.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.12.0
-initialReleaseDate: 2019-08-06
-lastRelease: 3.12.1
-futureVersion: 3.12.2
+initialVersion: 3.16.0
+initialReleaseDate: 2020-01-20
+lastRelease: 3.16.5
+futureVersion: 3.16.6
 channel: lts
-date: 2019-11-21
+date: 2020-03-23
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/lts.md
+++ b/data/project/ember/lts.md
@@ -7,8 +7,8 @@ filter:
 repo: emberjs/ember.js
 initialVersion: 3.16.0
 initialReleaseDate: 2020-01-20
-lastRelease: 3.16.5
-futureVersion: 3.16.6
+lastRelease: 3.16.6
+futureVersion: 3.16.7
 channel: lts
 date: 2020-03-23
 changelogPath: CHANGELOG.md


### PR DESCRIPTION
This PR addresses https://github.com/ember-learn/ember-website/issues/617.

## Changes made

- Updated the LTS Markdown data to show the most recent LTS version (3.16.6)
- Updated the LTS schedule table to show LTS versions that are currently supported (3.16, 3.12, 3.8)
- Added a paragraph about LTS versions that are no longer supported (3.4, 2.18, 2.16, 2.12, 2.8, 2.4)

## Source

I found determining the dates for bug fix, security patch, and EOL (end of life) from Ember blog posts to be confusing and error-prone. The 36- and 54-week patterns didn't always seem to occur.

Instead, I looked at the [changelog](https://github.com/emberjs/ember.js/blob/master/CHANGELOG.md) as the source of truth.

For bug fix and security patch, I took the x.x.0 minor release date and asked Google to add 36 weeks and 54 weeks, accordingly, to get approximate dates.

For EOL, I took the date of the last minor release (e.g. for Ember 3.4, I looked at the release date of 3.4.8, which is January 22, 2019).

 I'm not sure that these dates are considered correct, so can you help me double-check?