### PR TITLE
Fixed dates that appear in LTS schedule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,16 @@ If you want to add an existing Team Member to another team or change their team 
 To add a new team member you can run `ember g meetup city-country` and make sure that all the fields are filled in.
 
 The generated meetup will have two organisers but you can have as many, or as few as you need or want.
+
+### Updating LTS Channel page
+
+Roughly every 4 minor versions, and every final minor version before the next major release, a release of Ember gets promoted to LTS.
+
+Once a new LTS has been announced, please update the [LTS Channel page](https://emberjs.com/releases/lts/) by following these steps:
+
+- Update `app/controllers/releases/lts.js` to show currently supported LTS versions.
+- Update `data/project/ember/lts.md` to show the most recent LTS version.
+
+You can find out _when_ a release was promoted to LTS from the [changelog for Ember.js](https://github.com/emberjs/ember.js/blob/master/CHANGELOG.md). The LTS promotion date is the release date of the next minor version. For example, Ember 3.16 was promoted to LTS on [March 4, 2020](https://github.com/emberjs/ember.js/blob/master/CHANGELOG.md#v3170-march-4-2020) because that's the release date of v3.17.0.
+
+Don't worry about calculating dates for bugfixes and security patches. We made a helper, `add-weeks`, to do the math for you!

--- a/app/controllers/releases/lts.js
+++ b/app/controllers/releases/lts.js
@@ -1,0 +1,18 @@
+import Controller from '@ember/controller';
+
+export default class ReleasesLtsController extends Controller {
+  currentlySupportedLTS = [
+    {
+      version: '3.16',
+      promotionDate: new Date('March 4, 2020')
+    },
+    {
+      version: '3.12',
+      promotionDate: new Date('September 19, 2019')
+    },
+    {
+      version: '3.8',
+      promotionDate: new Date('April 1, 2019')
+    },
+  ];
+}

--- a/app/helpers/add-weeks.js
+++ b/app/helpers/add-weeks.js
@@ -1,0 +1,11 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(
+  function addWeeks([initialDate, numWeeks = 0]) {
+    let finalDate = new Date(initialDate);
+
+    finalDate.setDate(finalDate.getDate() + 7 * numWeeks);
+
+    return finalDate;
+  }
+);

--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -40,24 +40,14 @@
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>3.16</td>
-        <td>March 4, 2020</td>
-        <td>November 11, 2020</td>
-        <td>March 17, 2021</td>
-      </tr>
-      <tr>
-        <td>3.12</td>
-        <td>September 19, 2019</td>
-        <td>May 28, 2020</td>
-        <td>October 1, 2020</td>
-      </tr>
-      <tr>
-        <td>3.8</td>
-        <td>April 1, 2019</td>
-        <td>December 9, 2019</td>
-        <td>April 13, 2020</td>
-      </tr>
+      {{#each this.currentlySupportedLTS as |release|}}
+        <tr>
+          <td>{{release.version}}</td>
+          <td>{{format-date-time release.promotionDate "MMMM d, yyyy"}}</td>
+          <td>{{format-date-time (add-weeks release.promotionDate 36) "MMMM d, yyyy"}}</td>
+          <td>{{format-date-time (add-weeks release.promotionDate 54) "MMMM d, yyyy"}}</td>
+        </tr>
+      {{/each}}
     </tbody>
   </table>
 

--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -9,7 +9,9 @@
   <h2>What is an LTS release?</h2>
 
   <p>
-    LTS versions receive bugfixes for 36 weeks and security updates for 54 weeks.
+    Once a release of Ember gets promoted to LTS, it receives <strong>bugfixes for 36 weeks</strong> and <strong>security updates for 54 weeks</strong>.
+  </p>
+  <p>
     An LTS release is the best version to use if you won't be updating your app frequently,
     but want to help your app stay secure and working smoothly.
     Another reason to use an LTS is if you have a very large, complex app,
@@ -31,8 +33,8 @@
   <table>
     <thead>
       <tr>
-        <th>LTS Version</th>
-        <th>Released</th>
+        <th>LTS version</th>
+        <th>Promotion date</th>
         <th>Bugfixes until</th>
         <th>Security patches until</th>
       </tr>
@@ -40,21 +42,21 @@
     <tbody>
       <tr>
         <td>3.16</td>
-        <td>Jan 20, 2020</td>
-        <td>Sep 2020</td>
-        <td>Feb 2021</td>
+        <td>March 4, 2020</td>
+        <td>November 11, 2020</td>
+        <td>March 17, 2021</td>
       </tr>
       <tr>
         <td>3.12</td>
-        <td>Aug 5, 2019</td>
-        <td>Apr 2020</td>
-        <td>Aug 2020</td>
+        <td>September 19, 2019</td>
+        <td>May 28, 2020</td>
+        <td>October 1, 2020</td>
       </tr>
       <tr>
         <td>3.8</td>
-        <td>Feb 18, 2019</td>
-        <td>Oct 2019</td>
-        <td>Mar 2020</td>
+        <td>April 1, 2019</td>
+        <td>December 9, 2019</td>
+        <td>April 13, 2020</td>
       </tr>
     </tbody>
   </table>

--- a/tests/integration/helpers/add-weeks-test.js
+++ b/tests/integration/helpers/add-weeks-test.js
@@ -1,0 +1,78 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | add-weeks', function(hooks) {
+  setupRenderingTest(hooks);
+
+
+  test('by default, adds 0 weeks to the initial date', async function(assert) {
+    this.ltsRelease = {
+      version: '3.16',
+      promotionDate: new Date('March 4, 2020')
+    };
+
+    await render(hbs`
+      <table>
+        <thead>
+          <tr>
+            <th>LTS version</th>
+            <th>Promotion date</th>
+            <th>Bugfixes until</th>
+            <th>Security patches until</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{{this.ltsRelease.version}}</td>
+            <td>{{format-date-time this.ltsRelease.promotionDate "MMMM d, yyyy"}}</td>
+            <td data-test-column="Bugfixes">{{format-date-time (add-weeks this.ltsRelease.promotionDate) "MMMM d, yyyy"}}</td>
+            <td data-test-column="Security Patches">{{format-date-time (add-weeks this.ltsRelease.promotionDate) "MMMM d, yyyy"}}</td>
+          </tr>
+        </tbody>
+      </table>
+    `);
+
+    assert.dom('[data-test-column="Bugfixes"]')
+      .hasText('March 4, 2020', 'We see the correct date for bugfixes.');
+
+    assert.dom('[data-test-column="Security Patches"]')
+      .hasText('March 4, 2020', 'We see the correct date for security patches.');
+  });
+
+
+  test('can add any number of weeks to the initial date', async function(assert) {
+    this.ltsRelease = {
+      version: '3.16',
+      promotionDate: new Date('March 4, 2020')
+    };
+
+    await render(hbs`
+      <table>
+        <thead>
+          <tr>
+            <th>LTS version</th>
+            <th>Promotion date</th>
+            <th>Bugfixes until</th>
+            <th>Security patches until</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{{this.ltsRelease.version}}</td>
+            <td>{{format-date-time this.ltsRelease.promotionDate "MMMM d, yyyy"}}</td>
+            <td data-test-column="Bugfixes">{{format-date-time (add-weeks this.ltsRelease.promotionDate 36) "MMMM d, yyyy"}}</td>
+            <td data-test-column="Security Patches">{{format-date-time (add-weeks this.ltsRelease.promotionDate 54) "MMMM d, yyyy"}}</td>
+          </tr>
+        </tbody>
+      </table>
+    `);
+
+    assert.dom('[data-test-column="Bugfixes"]')
+      .hasText('November 11, 2020', 'We see the correct date for bugfixes.');
+
+    assert.dom('[data-test-column="Security Patches"]')
+      .hasText('March 17, 2021', 'We see the correct date for security patches.');
+  });
+});


### PR DESCRIPTION
## Background

This PR addresses the issue #634 .

When I worked on PR #627, I was confused by when exactly a release of Ember gets promoted to LTS and how to calculate the dates for bugfixes and security patches.

## Code changes

In this PR, I made 3 changes.

First, I corrected the dates that are currently shown on the [LTS Channel page](https://emberjs.com/releases/lts/).

Second, I created a helper called `add-weeks` to prevent human error in finding the dates for bugfixes and security patches. The dates for LTS promotion are stored in the `releases.lts` controller. (They could be returned from the route's `model` hook, but the hook was used for something else and I didn't feel like complicating the PR.)

Lastly, I documented how one can check dates related to LTS releases in `CONTRIBUTING.md` so that anyone can update the LTS Channel page in the future.