### PR TITLE
Updating release data to 3.17

### DIFF
--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -5,14 +5,14 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.16.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-lastRelease: 3.17.0-beta.5 # Manually update
-futureVersion: 3.17.0-beta.5 # Manually update
-finalVersion: 3.17.0 # Manually update
+initialVersion: 3.17.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+lastRelease: 3.18.0-beta.5 # Manually update
+futureVersion: 3.18.0-beta.5 # Manually update
+finalVersion: 3.18.0 # Manually update
 channel: beta
-cycleEstimatedFinishDate: 2020-03-02 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
-date: 2020-02-18 # Manually update, get date for `lastRelease`
-nextDate: 2020-03-02 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+cycleEstimatedFinishDate: 2020-04-13 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+date: 2020-03-05 # Manually update, get date for `lastRelease`
+nextDate: 2020-04-13 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.16.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-initialReleaseDate: 2020-01-20 # Manually update
-lastRelease: 3.16.3 # Manually update
-futureVersion: 3.16.4 # Manually update
+initialVersion: 3.17.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+initialReleaseDate: 2020-03-05 # Manually update
+lastRelease: 3.17.3 # Manually update
+futureVersion: 3.17.4 # Manually update
 channel: release
-date: 2020-02-18 # Manually update, is today's date
+date: 2020-04-13 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -4,11 +4,11 @@ baseFileName: ember-data
 filter:
  - /ember-data\./
 repo: emberjs/data
-lastRelease: 3.17.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-futureVersion: 3.17.0-beta.1 # Manually update
-finalVersion: 3.17.0 # Manually update
+lastRelease: 3.18.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+futureVersion: 3.18.0-beta.0 # Manually update
+finalVersion: 3.18.0 # Manually update
 channel: beta
-date: 2020-01-25 # Manually update, get date for `lastRelease` 
+date: 2020-03-11 # Manually update, get date for `lastRelease` 
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ignoreFiles:

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -4,12 +4,12 @@ baseFileName: ember-data
 filter:
   - /ember-data\./
 repo: emberjs/data
-initialVersion: 3.16.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-initialReleaseDate: 2020-01-25 # Manually update, get date for `initialVersion` 
-lastRelease: 3.16.0 # Manually update
-futureVersion: 3.17.0 # Manually update
+initialVersion: 3.17.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+initialReleaseDate: 2020-03-11 # Manually update, get date for `initialVersion` 
+lastRelease: 3.17.0 # Manually update
+futureVersion: 3.18.0 # Manually update
 channel: release
-date: 2020-02-18 # Manually update, is today's date
+date: 2020-04-13 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ---


### PR DESCRIPTION
The release data on the site for latest and beta has been out of date since 3.16 went LTS, so before 3.18 got as far as a blog post, I figured I'd submit the change for 3.17. Hopefully I got everything right.