### PR TITLE
adjust beta release cycle

### DIFF
--- a/app/components/release-timeline.js
+++ b/app/components/release-timeline.js
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+
+export default class ReleaseTimelineComponent extends Component {
+    get betaList() {
+        let currentBeta = parseInt(this.args.project.lastRelease.match(/\d+$/)[0], 10);
+
+        return new Array(currentBeta).fill(null).map((_, i) => i+1);
+    }
+}

--- a/app/templates/components/release-timeline.hbs
+++ b/app/templates/components/release-timeline.hbs
@@ -7,30 +7,12 @@
   <div class="path-to-release">
     <div class="bold">The path to {{@project.finalVersion}}...</div>
     <div class="steps">
-      {{project-listing/beta
-          version=1
-          project=@project
-      }}
-      {{project-listing/beta
-          version=2
-          project=@project
-      }}
-      {{project-listing/beta
-          version=3
-          project=@project
-      }}
-      {{project-listing/beta
-          version=4
-          project=@project
-      }}
-      {{project-listing/beta
-          version=5
-          project=@project
-      }}
-      {{project-listing/beta
-          version=6
-          project=@project
-      }}
+      {{#each this.betaList as |oneIndexed|}}
+        {{project-listing/beta
+            version=oneIndexed
+            project=@project
+        }}
+      {{/each}}
     </div>
   </div>
   <div class="release future-image">

--- a/tests/integration/components/release-timeline-test.js
+++ b/tests/integration/components/release-timeline-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | release-timeline', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<ReleaseTimeline />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <ReleaseTimeline>
+        template block text
+      </ReleaseTimeline>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});


### PR DESCRIPTION
The intention is to remove the expectation of the weekly beta, and instead show which betas are actually out for the current cycle.

It also seems strange that this graph is not present in the beta page as well?