### PR TITLE
Make Twitter optional on team member page

### DIFF
--- a/app/templates/components/team-list.hbs
+++ b/app/templates/components/team-list.hbs
@@ -14,7 +14,9 @@
         </div>
         <div>
           <a aria-label="{{member.name}} Github Profile" class="icon" href={{member.github}}>{{svg-jar "github"}}</a>
-          <a aria-label="{{member.name}} Twitter" class="icon" href={{member.twitter}}>{{svg-jar "twitter"}}</a>
+          {{#if member.twitter}}
+            <a aria-label="{{member.name}} Twitter" class="icon" href={{member.twitter}}>{{svg-jar "twitter"}}</a>
+          {{/if}}
         </div>
       </div>
     {{/each}}


### PR DESCRIPTION
WAS: 
Twitter icon appears w/ no link

IS:
![image](https://user-images.githubusercontent.com/1372946/85082477-d6c09980-b183-11ea-8af5-84edd0cbce43.png)
