### PR TITLE
Updated Releases pages for v3.21 release

### DIFF
--- a/app/controllers/releases/lts.js
+++ b/app/controllers/releases/lts.js
@@ -3,16 +3,16 @@ import Controller from '@ember/controller';
 export default class ReleasesLtsController extends Controller {
   currentlySupportedLTS = [
     {
+      version: '3.20',
+      promotionDate: new Date('August 24, 2020')
+    },
+    {
       version: '3.16',
       promotionDate: new Date('March 4, 2020')
     },
     {
       version: '3.12',
       promotionDate: new Date('September 19, 2019')
-    },
-    {
-      version: '3.8',
-      promotionDate: new Date('April 1, 2019')
     },
   ];
 }

--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -52,6 +52,6 @@
   </table>
 
   <p>
-    These LTS versions are no longer maintained: 3.4 (Jan 2019), 2.18 (Feb 2018), 2.16 (Feb 2018), 2.12 (Apr 2017), 2.8 (Nov 2016), and 2.4 (Apr 2016). Their last minor release dates are shown in parentheses.
+    These LTS versions are no longer maintained: 3.8 (Aug 2019), 3.4 (Jan 2019), 2.18 (Feb 2018), 2.16 (Feb 2018), 2.12 (Apr 2017), 2.8 (Nov 2016), and 2.4 (Apr 2016). Their last minor release dates are shown in parentheses.
   </p>
 {{/project-listing}}

--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -5,14 +5,14 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.20.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-lastRelease: 3.21.0-beta.3 # Manually update
-futureVersion: 3.21.0-beta.4 # Manually update
-finalVersion: 3.21.0 # Manually update
+initialVersion: 3.21.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+lastRelease: 3.22.0-beta.2 # Manually update
+futureVersion: 3.22.0-beta.3 # Manually update
+finalVersion: 3.22.0 # Manually update
 channel: beta
-cycleEstimatedFinishDate: 2020-08-24 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
-date: 2020-07-27 # Manually update, get date for `lastRelease`
-nextDate: 2020-08-24 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+cycleEstimatedFinishDate: 2020-10-05 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+date: 2020-08-31 # Manually update, get date for `lastRelease`
+nextDate: 2020-10-05 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/lts.md
+++ b/data/project/ember/lts.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.16.0
-initialReleaseDate: 2020-01-20
-lastRelease: 3.16.6
-futureVersion: 3.16.7
+initialVersion: 3.20.0
+initialReleaseDate: 2020-07-13
+lastRelease: 3.20.5
+futureVersion: 3.20.6
 channel: lts
-date: 2020-03-23
+date: 2020-09-09
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.20.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-initialReleaseDate: 2020-07-13 # Manually update
-lastRelease: 3.20.2 # Manually update
-futureVersion: 3.20.3 # Manually update
+initialVersion: 3.21.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+initialReleaseDate: 2020-08-24 # Manually update
+lastRelease: 3.21.1 # Manually update
+futureVersion: 3.21.2 # Manually update
 channel: release
-date: 2020-07-29 # Manually update, is today's date
+date: 2020-09-09 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -4,11 +4,11 @@ baseFileName: ember-data
 filter:
  - /ember-data\./
 repo: emberjs/data
-lastRelease: 3.21.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-futureVersion: 3.21.0-beta.1 # Manually update
-finalVersion: 3.21.0 # Manually update
+lastRelease: 3.22.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+futureVersion: 3.22.0-beta.1 # Manually update
+finalVersion: 3.22.0 # Manually update
 channel: beta
-date: 2020-07-29 # Manually update, get date for `lastRelease` 
+date: 2020-08-31 # Manually update, get date for `lastRelease` 
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ignoreFiles:

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -4,12 +4,12 @@ baseFileName: ember-data
 filter:
   - /ember-data\./
 repo: emberjs/data
-initialVersion: 3.20.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-initialReleaseDate: 2020-04-28 # Manually update, get date for `initialVersion` 
-lastRelease: 3.20.0 # Manually update
-futureVersion: 3.21.0 # Manually update
+initialVersion: 3.21.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+initialReleaseDate: 2020-08-31 # Manually update, get date for `initialVersion` 
+lastRelease: 3.21.0 # Manually update
+futureVersion: 3.21.1 # Manually update
 channel: release
-date: 2020-04-28 # Manually update, is today's date
+date: 2020-09-09 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ---


### PR DESCRIPTION
## Description

@bouke kindly informed us on [Discourse](https://discuss.emberjs.com/t/ember-js-ember-3-21-released/18183/2) that we didn't update the Releases pages after `v3.20` was promoted to LTS.


## How to Review

I recommend reviewing commits one at a time.