### PR TITLE
Adjusted blog post release date

### DIFF
--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -10,7 +10,7 @@ initialReleaseDate: 2020-10-05 # Manually update
 lastRelease: 3.22.0 # Manually update
 futureVersion: 3.22.1 # Manually update
 channel: release
-date: 2020-10-19 # Manually update, is today's date
+date: 2020-10-20 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -9,7 +9,7 @@ initialReleaseDate: 2020-10-09 # Manually update, get date for `initialVersion`
 lastRelease: 3.22.0 # Manually update
 futureVersion: 3.22.1 # Manually update
 channel: release
-date: 2020-10-19 # Manually update, is today's date
+date: 2020-10-20 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ---


### PR DESCRIPTION
## Background

We had a 1-day delay in compiling API docs and publishing the blog post for release announcement. For consistency, let's shift the `date` in `release.md` by 1.