### PR TITLE
Remove RFC Tracking section

### DIFF
--- a/app/templates/learn/index.hbs
+++ b/app/templates/learn/index.hbs
@@ -143,14 +143,6 @@
     </ul>
   </section>
 
-  <section class="mb-3" aria-labelledby="learning-emberjs-rfc-tracking">
-    <h2 id="learning-emberjs-rfc-tracking">RFC Tracking</h2>
-
-    <p>
-      Interested in seeing the overall picture of what we're working on next? Check out our <a href="https://github.com/emberjs/rfc-tracking/issues" rel="nofollow noopener noreferrer" target="_blank">RFC Tracking</a> issues for more details!
-    </p>
-  </section>
-
   <section class="mb-3" aria-labelledby="learning-emberjs-faq">
     <h2 id="learning-emberjs-faq">Frequently Asked Questions</h2>
 


### PR DESCRIPTION
Given that the tracking initiative is not really representative of the current state of development and RFC Stages will eventually replace it, I think we should not point our community to it.