### PR TITLE
Update SupportedLTS's

### DIFF
--- a/app/controllers/releases/lts.js
+++ b/app/controllers/releases/lts.js
@@ -1,18 +1,14 @@
-import Controller from '@ember/controller';
+import Controller from "@ember/controller";
 
 export default class ReleasesLtsController extends Controller {
   currentlySupportedLTS = [
     {
-      version: '3.20',
-      promotionDate: new Date('August 24, 2020')
+      version: "3.20",
+      promotionDate: new Date("August 24, 2020"),
     },
     {
-      version: '3.16',
-      promotionDate: new Date('March 4, 2020')
-    },
-    {
-      version: '3.12',
-      promotionDate: new Date('September 19, 2019')
+      version: "3.16",
+      promotionDate: new Date("March 4, 2020"),
     },
   ];
 }

--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -52,6 +52,6 @@
   </table>
 
   <p>
-    These LTS versions are no longer maintained: 3.8 (Aug 2019), 3.4 (Jan 2019), 2.18 (Feb 2018), 2.16 (Feb 2018), 2.12 (Apr 2017), 2.8 (Nov 2016), and 2.4 (Apr 2016). Their last minor release dates are shown in parentheses.
+    These LTS versions are no longer maintained: 3.12 (Oct 2020), 3.8 (Aug 2019), 3.4 (Jan 2019), 2.18 (Feb 2018), 2.16 (Feb 2018), 2.12 (Apr 2017), 2.8 (Nov 2016), and 2.4 (Apr 2016). Their last minor release dates are shown in parentheses.
   </p>
 </ProjectListing>


### PR DESCRIPTION
According to the support policy, ember@3.12 is no longer in support (as
of October 2020);

I noticed this, as I was implementing "support policy window tooling",
which disagreed with the fixture data harvested from this site. After
investigating, it appears this site's data may be out of date. Or I
misunderstand ember LTS policy.