### PR TITLE
Updated Releases pages for Ember v3.23 release

### DIFF
--- a/app/templates/releases/index.hbs
+++ b/app/templates/releases/index.hbs
@@ -16,9 +16,9 @@
 
 <p>
   Read more about our
-  <LinkTo @route="releases.lts">Long Term Support,</LinkTo>
-  <LinkTo @route="releases.release">latest stable,</LinkTo>
-  <LinkTo @route="releases.beta">beta,</LinkTo>
+  <LinkTo @route="releases.lts">Long Term Support</LinkTo>,
+  <LinkTo @route="releases.release">latest stable</LinkTo>,
+  <LinkTo @route="releases.beta">beta</LinkTo>,
   and <LinkTo @route="releases.canary">canary</LinkTo>
   releases.
 </p>

--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -5,14 +5,14 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.22.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-lastRelease: 3.23.0-beta.1 # Manually update
-futureVersion: 3.23.0-beta.2 # Manually update
-finalVersion: 3.23.0 # Manually update
+initialVersion: 3.23.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+lastRelease: 3.24.0-beta.1 # Manually update
+futureVersion: 3.24.0-beta.2 # Manually update
+finalVersion: 3.24.0 # Manually update
 channel: beta
-cycleEstimatedFinishDate: 2020-11-16 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
-date: 2020-10-05 # Manually update, get date for `lastRelease`
-nextDate: 2020-11-16 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+cycleEstimatedFinishDate: 2020-12-28 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+date: 2020-11-17 # Manually update, get date for `lastRelease`
+nextDate: 2020-12-28 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/lts.md
+++ b/data/project/ember/lts.md
@@ -7,8 +7,8 @@ filter:
 repo: emberjs/ember.js
 initialVersion: 3.20.0
 initialReleaseDate: 2020-07-13
-lastRelease: 3.20.5
-futureVersion: 3.20.6
+lastRelease: 3.20.6
+futureVersion: 3.20.7
 channel: lts
 date: 2020-09-09
 changelogPath: CHANGELOG.md

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.22.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-initialReleaseDate: 2020-10-05 # Manually update
-lastRelease: 3.22.0 # Manually update
-futureVersion: 3.22.1 # Manually update
+initialVersion: 3.23.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+initialReleaseDate: 2020-11-16 # Manually update
+lastRelease: 3.23.1 # Manually update
+futureVersion: 3.23.2 # Manually update
 channel: release
-date: 2020-10-20 # Manually update, is today's date
+date: 2020-12-14 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -4,11 +4,11 @@ baseFileName: ember-data
 filter:
  - /ember-data\./
 repo: emberjs/data
-lastRelease: 3.23.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-futureVersion: 3.23.0-beta.1 # Manually update
-finalVersion: 3.23.0 # Manually update
+lastRelease: 3.24.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+futureVersion: 3.24.0-beta.1 # Manually update
+finalVersion: 3.24.0 # Manually update
 channel: beta
-date: 2020-10-09 # Manually update, get date for `lastRelease` 
+date: 2020-11-30 # Manually update, get date for `lastRelease` 
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ignoreFiles:

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -4,12 +4,12 @@ baseFileName: ember-data
 filter:
   - /ember-data\./
 repo: emberjs/data
-initialVersion: 3.22.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-initialReleaseDate: 2020-10-09 # Manually update, get date for `initialVersion` 
-lastRelease: 3.22.0 # Manually update
-futureVersion: 3.22.1 # Manually update
+initialVersion: 3.23.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+initialReleaseDate: 2020-12-01 # Manually update, get date for `initialVersion`
+lastRelease: 3.23.0 # Manually update
+futureVersion: 3.23.1 # Manually update
 channel: release
-date: 2020-10-20 # Manually update, is today's date
+date: 2020-12-14 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ---


### PR DESCRIPTION
~⚠️ This is work in progress.~

We're waiting for `ember-cli v3.23` and blog post to be released before merging this pull request. The today's date in `release.md` will need to coincide with the release date of the blog post.