### PR TITLE
Updated Beta Channel page

### DIFF
--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -6,12 +6,12 @@ filter:
   - /ember-template-compiler/
 repo: emberjs/ember.js
 initialVersion: 3.23.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-lastRelease: 3.24.0-beta.1 # Manually update
-futureVersion: 3.24.0-beta.2 # Manually update
+lastRelease: 3.24.0-beta.3 # Manually update
+futureVersion: 3.24.0-beta.4 # Manually update
 finalVersion: 3.24.0 # Manually update
 channel: beta
 cycleEstimatedFinishDate: 2020-12-28 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
-date: 2020-11-17 # Manually update, get date for `lastRelease`
+date: 2020-12-21 # Manually update, get date for `lastRelease`
 nextDate: 2020-12-28 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js

--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -11,7 +11,7 @@ futureVersion: 3.24.0-beta.4 # Manually update
 finalVersion: 3.24.0 # Manually update
 channel: beta
 cycleEstimatedFinishDate: 2020-12-28 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
-date: 2020-12-21 # Manually update, get date for `lastRelease`
+date: 2020-11-17 # Manually update, get date for `initialVersion`
 nextDate: 2020-12-28 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js


### PR DESCRIPTION
## Description

`ember-source` recently released `v3.24.0-beta.3` so I wanted to update the [Beta Channel](https://emberjs.com/releases/beta) page.


## References

- https://github.com/emberjs/ember.js/blob/v3.24.0-beta.3/CHANGELOG.md#v3240-beta3-december-21-2020