### PR TITLE
Updated Releases pages for Ember v3.24 release

### DIFF
--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -5,14 +5,14 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.23.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-lastRelease: 3.24.0-beta.3 # Manually update
-futureVersion: 3.24.0-beta.4 # Manually update
-finalVersion: 3.24.0 # Manually update
+initialVersion: 3.24.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+lastRelease: 3.25.0-beta.1 # Manually update
+futureVersion: 3.25.0-beta.2 # Manually update
+finalVersion: 3.25.0 # Manually update
 channel: beta
-cycleEstimatedFinishDate: 2020-12-28 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
-date: 2020-11-17 # Manually update, get date for `initialVersion`
-nextDate: 2020-12-28 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+cycleEstimatedFinishDate: 2021-02-08 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+date: 2020-12-28 # Manually update, get date for `initialVersion`
+nextDate: 2021-02-08 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.23.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-initialReleaseDate: 2020-11-16 # Manually update
-lastRelease: 3.23.1 # Manually update
-futureVersion: 3.23.2 # Manually update
+initialVersion: 3.24.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+initialReleaseDate: 2020-12-28 # Manually update
+lastRelease: 3.24.0 # Manually update
+futureVersion: 3.24.1 # Manually update
 channel: release
-date: 2020-12-14 # Manually update, is today's date
+date: 2021-01-07 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -4,11 +4,11 @@ baseFileName: ember-data
 filter:
  - /ember-data\./
 repo: emberjs/data
-lastRelease: 3.24.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-futureVersion: 3.24.0-beta.1 # Manually update
-finalVersion: 3.24.0 # Manually update
+lastRelease: 3.25.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+futureVersion: 3.25.0-beta.1 # Manually update
+finalVersion: 3.25.0 # Manually update
 channel: beta
-date: 2020-11-30 # Manually update, get date for `lastRelease` 
+date: 2021-01-05 # Manually update, get date for `lastRelease` 
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ignoreFiles:

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -4,12 +4,12 @@ baseFileName: ember-data
 filter:
   - /ember-data\./
 repo: emberjs/data
-initialVersion: 3.23.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-initialReleaseDate: 2020-12-01 # Manually update, get date for `initialVersion`
-lastRelease: 3.23.0 # Manually update
-futureVersion: 3.23.1 # Manually update
+initialVersion: 3.24.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+initialReleaseDate: 2021-01-05 # Manually update, get date for `initialVersion`
+lastRelease: 3.24.0 # Manually update
+futureVersion: 3.24.1 # Manually update
 channel: release
-date: 2020-12-14 # Manually update, is today's date
+date: 2021-01-07 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ---


### PR DESCRIPTION
## Description

I followed the instructions in the Markdown files, then updated release versions and dates for the upcoming 3.24 release.


## Notes

⚠️ This pull request can be merged after the release blog post is published (estimated date: Jan 7). If there's a delay, the today's date in `release.md` will need to coincide with the release date of the blog post.