### PR TITLE
Added tests to better document the project (Part 2)

### DIFF
--- a/app/components/project-listing/beta/component.js
+++ b/app/components/project-listing/beta/component.js
@@ -5,6 +5,10 @@ export default Component.extend({
   tagName: '',
 
   currentBetaNumber: computed('project.lastRelease', function () {
+    if (!this.project?.lastRelease) {
+      return undefined;
+    }
+
     let versionParts = this.project.lastRelease.split('.');
     return parseInt(versionParts[versionParts.length - 1], 10);
   }),

--- a/app/components/tomster-list.js
+++ b/app/components/tomster-list.js
@@ -9,13 +9,13 @@ export default Component.extend({
   sortedModel: sort('filteredModel', 'sorting'),
 
   filteredModel: computed('filter', 'tomsters', function () {
+    const tomsters = this.tomsters ?? [];
+
     if (this.filter === 'all') {
-      return this.tomsters;
+      return tomsters;
     }
 
-    return this.tomsters.filter((tomster) =>
-      tomster.tags.includes(this.filter)
-    );
+    return tomsters.filter((tomster) => tomster.tags.includes(this.filter));
   }),
 
   displayClass: computed('display', function () {

--- a/app/helpers/capitalize.js
+++ b/app/helpers/capitalize.js
@@ -2,6 +2,10 @@ import { helper } from '@ember/component/helper';
 import { capitalize as capitalizeUtil } from '@ember/string';
 
 export function capitalize([name] /*, hash*/) {
+  if (!name) {
+    return '';
+  }
+
   return capitalizeUtil(name);
 }
 

--- a/tests/integration/components/addon-tabs-test.js
+++ b/tests/integration/components/addon-tabs-test.js
@@ -1,13 +1,16 @@
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { click, focus, render, triggerKeyEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
 
 module('Integration | Component | addon-tabs', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it activates a tab when clicking on it', async function (assert) {
-    await render(hbs`<AddonTabs />`);
+    await render(hbs`
+      <AddonTabs />
+    `);
+
     let firstTab = assert.dom('#addon-tab-0');
     let firstPanel = assert.dom('#addon-panel-0');
 
@@ -30,7 +33,9 @@ module('Integration | Component | addon-tabs', function (hooks) {
   });
 
   test("it's possible to change the active tab by pressing the arrow keys when focused on the currently active tab", async function (assert) {
-    await render(hbs`<AddonTabs />`);
+    await render(hbs`
+      <AddonTabs />
+    `);
 
     let totalTabs = this.element.querySelectorAll('[role=tab]').length;
     let firstTabSelector = `#addon-tab-0`;

--- a/tests/integration/components/addon-tabs/panel-test.js
+++ b/tests/integration/components/addon-tabs/panel-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | addon-tabs/panel', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <AddonTabs::Panel />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/addon-tabs/tab-test.js
+++ b/tests/integration/components/addon-tabs/tab-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | addon-tabs/tab', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <AddonTabs::Tab />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/black-lives-matter-banner-test.js
+++ b/tests/integration/components/black-lives-matter-banner-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | black-lives-matter-banner', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <BlackLivesMatterBanner />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/cta-emberconf-test.js
+++ b/tests/integration/components/cta-emberconf-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | cta-emberconf', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <CtaEmberconf />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/ecosystem-icon-test.js
+++ b/tests/integration/components/ecosystem-icon-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | ecosystem-icon', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <EcosystemIcon />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/ecosystem-icons-test.js
+++ b/tests/integration/components/ecosystem-icons-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | ecosystem-icons', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <EcosystemIcons />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/ember-survey-test.js
+++ b/tests/integration/components/ember-survey-test.js
@@ -1,13 +1,12 @@
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
 
 module('Integration | Component | ember-survey', function (hooks) {
   setupRenderingTest(hooks);
 
-  let template = hbs`{{ember-survey}}`;
   let surveySelector = '.survey-reminder-wrapper';
 
   module('A survey is configured', function (hooks) {
@@ -28,7 +27,11 @@ module('Integration | Component | ember-survey', function (hooks) {
           currentRouteName: 'mascots',
         })
       );
-      await render(template);
+
+      await render(hbs`
+        <EmberSurvey />
+      `);
+
       assert.dom(surveySelector).exists();
     });
 
@@ -42,11 +45,15 @@ module('Integration | Component | ember-survey', function (hooks) {
         );
       });
 
-      let templateWithToday = hbs`{{ember-survey today=today}}`;
-
       test('it renders the time remaining to take the survey when it is the current survey page', async function (assert) {
         this.set('today', Date.UTC(2019, 2, 1));
-        await render(templateWithToday);
+
+        await render(hbs`
+          <EmberSurvey
+            @today={{this.today}}
+          />
+        `);
+
         assert
           .dom(surveySelector)
           .hasText('You have 11 days left to submit your response! x');
@@ -54,7 +61,13 @@ module('Integration | Component | ember-survey', function (hooks) {
 
       test('with one day left to submit', async function (assert) {
         this.set('today', Date.UTC(2019, 2, 11));
-        await render(templateWithToday);
+
+        await render(hbs`
+          <EmberSurvey
+            @today={{this.today}}
+          />
+        `);
+
         assert
           .dom(surveySelector)
           .hasText('You have 1 day left to submit your response! x');
@@ -62,7 +75,13 @@ module('Integration | Component | ember-survey', function (hooks) {
 
       test('with 0 days left to submit', async function (assert) {
         this.set('today', Date.UTC(2019, 2, 12));
-        await render(templateWithToday);
+
+        await render(hbs`
+          <EmberSurvey
+            @today={{this.today}}
+          />
+        `);
+
         assert
           .dom(surveySelector)
           .hasText('You have today left to submit your response! x');

--- a/tests/integration/components/grid-dots-test.js
+++ b/tests/integration/components/grid-dots-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | grid-dots', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <GridDots />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/high-charts-test.js
+++ b/tests/integration/components/high-charts-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, skip } from 'qunit';
+
+module('Integration | Component | high-charts', function (hooks) {
+  setupRenderingTest(hooks);
+
+  skip('it renders', async function (assert) {
+    await render(hbs`
+      <HighCharts />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/homepage-image-grid-test.js
+++ b/tests/integration/components/homepage-image-grid-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | homepage-image-grid', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <HomepageImageGrid />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/project-listing-test.js
+++ b/tests/integration/components/project-listing-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | project-listing', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <ProjectListing />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/project-listing/beta-test.js
+++ b/tests/integration/components/project-listing/beta-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | project-listing/beta', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <ProjectListing::Beta />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/release-timeline-test.js
+++ b/tests/integration/components/release-timeline-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | release-timeline', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <ReleaseTimeline />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/remove-spinner-test.js
+++ b/tests/integration/components/remove-spinner-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | remove-spinner', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <RemoveSpinner />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/team-list-test.js
+++ b/tests/integration/components/team-list-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | team-list', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <TeamList />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/terminal-code-test.js
+++ b/tests/integration/components/terminal-code-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | terminal-code', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <TerminalCode />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/components/tomster-list-test.js
+++ b/tests/integration/components/tomster-list-test.js
@@ -1,0 +1,16 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | tomster-list', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <TomsterList />
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/unit/serializers/application-test.js
+++ b/tests/unit/serializers/application-test.js
@@ -1,0 +1,23 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Serializer | application', function (hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let serializer = store.serializerFor('application');
+
+    assert.ok(serializer);
+  });
+
+  test('it serializes records', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let record = store.createRecord('tomster', {});
+
+    let serializedRecord = record.serialize();
+
+    assert.ok(serializedRecord);
+  });
+});


### PR DESCRIPTION
## Background

Over the next month, I want to make several pull requests so that we can upgrade `ember-source` from `v3.20` to `v3.24`.


## Description

In this pull request, I added unit tests for `application` serializer and default rendering tests for components.

The tests for components, in particular, will help us migrate the components layout from classic pre-Octane (template files in `app/templates`) to classic Octane (colocated in `app/components`).

The default rendering tests also help us check that the code in a backing class can run without error when the arguments are undefined.