### PR TITLE
Added tests to better document the project (Part 4)

### DIFF
--- a/tests/acceptance/about/legal-test.js
+++ b/tests/acceptance/about/legal-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,13 @@ module('Acceptance | about/legal', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/about/legal');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/about/legal');
+    await a11yAudit();
 
     assert.ok(true);
   });

--- a/tests/acceptance/community-test.js
+++ b/tests/acceptance/community-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, skip } from 'qunit';
 
@@ -18,6 +19,13 @@ module('Acceptance | community', function (hooks) {
   skip('Percy snapshot', async function (assert) {
     await visit('/community');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  skip('Accessibility audit', async function (assert) {
+    await visit('/community');
+    await a11yAudit();
 
     assert.ok(true);
   });

--- a/tests/acceptance/community/black-lives-matter-test.js
+++ b/tests/acceptance/community/black-lives-matter-test.js
@@ -4,7 +4,7 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, skip } from 'qunit';
 
-module('Acceptance | community/meetups getting started', function (hooks) {
+module('Acceptance | community/black lives matter', function (hooks) {
   setupApplicationTest(hooks);
 
   /*
@@ -17,14 +17,14 @@ module('Acceptance | community/meetups getting started', function (hooks) {
     setting, let's skip the Percy snapshot.
   */
   skip('Percy snapshot', async function (assert) {
-    await visit('/community/meetups-getting-started');
+    await visit('/community/black-lives-matter');
     await percySnapshot(assert);
 
     assert.ok(true);
   });
 
   skip('Accessibility audit', async function (assert) {
-    await visit('/community/meetups-getting-started');
+    await visit('/community/black-lives-matter');
     await a11yAudit();
 
     assert.ok(true);

--- a/tests/acceptance/community/meetups-test.js
+++ b/tests/acceptance/community/meetups-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, skip } from 'qunit';
 
@@ -18,6 +19,13 @@ module('Acceptance | community/meetups', function (hooks) {
   skip('Percy snapshot', async function (assert) {
     await visit('/community/meetups');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  skip('Accessibility audit', async function (assert) {
+    await visit('/community/meetups');
+    await a11yAudit();
 
     assert.ok(true);
   });

--- a/tests/acceptance/community/meetups/assets-test.js
+++ b/tests/acceptance/community/meetups/assets-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,13 @@ module('Acceptance | community/meetups/assets', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/community/meetups/assets');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/community/meetups/assets');
+    await a11yAudit();
 
     assert.ok(true);
   });

--- a/tests/acceptance/editions-test.js
+++ b/tests/acceptance/editions-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,13 @@ module('Acceptance | editions', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/editions');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/editions');
+    await a11yAudit();
 
     assert.ok(true);
   });

--- a/tests/acceptance/editions/octane-test.js
+++ b/tests/acceptance/editions/octane-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,22 @@ module('Acceptance | editions/octane', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/editions/octane');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/editions/octane');
+    await a11yAudit({
+      rules: {
+        'aria-valid-attr-value': {
+          enabled: false,
+        },
+        'heading-order': {
+          enabled: false,
+        },
+      },
+    });
 
     assert.ok(true);
   });

--- a/tests/acceptance/ember-community-survey-2019-test.js
+++ b/tests/acceptance/ember-community-survey-2019-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, skip } from 'qunit';
 
@@ -23,6 +24,13 @@ module('Acceptance | ember-community-survey-2019', function (hooks) {
   skip('Percy snapshot', async function (assert) {
     await visit('/ember-community-survey-2019');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  skip('Accessibility audit', async function (assert) {
+    await visit('/ember-community-survey-2019');
+    await a11yAudit();
 
     assert.ok(true);
   });

--- a/tests/acceptance/ember-users-test.js
+++ b/tests/acceptance/ember-users-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,13 @@ module('Acceptance | ember-users', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/ember-users');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/ember-users');
+    await a11yAudit();
 
     assert.ok(true);
   });

--- a/tests/acceptance/guidelines-test.js
+++ b/tests/acceptance/guidelines-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,13 @@ module('Acceptance | guidelines', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/guidelines');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/guidelines');
+    await a11yAudit();
 
     assert.ok(true);
   });

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, skip } from 'qunit';
 
@@ -18,6 +19,19 @@ module('Acceptance | index', function (hooks) {
   skip('Percy snapshot', async function (assert) {
     await visit('/');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  skip('Accessibility audit', async function (assert) {
+    await visit('/');
+    await a11yAudit({
+      rules: {
+        'scrollable-region-focusable': {
+          enabled: false,
+        },
+      },
+    });
 
     assert.ok(true);
   });

--- a/tests/acceptance/learn-test.js
+++ b/tests/acceptance/learn-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,13 @@ module('Acceptance | learn', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/learn');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/learn');
+    await a11yAudit();
 
     assert.ok(true);
   });

--- a/tests/acceptance/logos-test.js
+++ b/tests/acceptance/logos-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,13 @@ module('Acceptance | logos', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/logos');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/logos');
+    await a11yAudit();
 
     assert.ok(true);
   });

--- a/tests/acceptance/mascots-test.js
+++ b/tests/acceptance/mascots-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,13 @@ module('Acceptance | mascots', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/mascots');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/mascots');
+    await a11yAudit();
 
     assert.ok(true);
   });

--- a/tests/acceptance/mascots/commission-test.js
+++ b/tests/acceptance/mascots/commission-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,22 @@ module('Acceptance | mascots/commission', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/mascots/commission');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/mascots/commission');
+    await a11yAudit({
+      rules: {
+        'color-contrast': {
+          enabled: false,
+        },
+        label: {
+          enabled: false,
+        },
+      },
+    });
 
     assert.ok(true);
   });

--- a/tests/acceptance/mascots/faq-test.js
+++ b/tests/acceptance/mascots/faq-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,13 @@ module('Acceptance | mascots/faq', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/mascots/faq');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/mascots/faq');
+    await a11yAudit();
 
     assert.ok(true);
   });

--- a/tests/acceptance/mascots/payment-test.js
+++ b/tests/acceptance/mascots/payment-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,19 @@ module('Acceptance | mascots/payment', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/mascots/payment');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/mascots/payment');
+    await a11yAudit({
+      rules: {
+        'color-contrast': {
+          enabled: false,
+        },
+      },
+    });
 
     assert.ok(true);
   });

--- a/tests/acceptance/releases-test.js
+++ b/tests/acceptance/releases-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,22 @@ module('Acceptance | releases', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/releases');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/releases');
+    await a11yAudit({
+      rules: {
+        'color-contrast': {
+          enabled: false,
+        },
+        'image-alt': {
+          enabled: false,
+        },
+      },
+    });
 
     assert.ok(true);
   });

--- a/tests/acceptance/releases/beta-test.js
+++ b/tests/acceptance/releases/beta-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,19 @@ module('Acceptance | releases/beta', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/releases/beta');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/releases/beta');
+    await a11yAudit({
+      rules: {
+        'heading-order': {
+          enabled: false,
+        },
+      },
+    });
 
     assert.ok(true);
   });

--- a/tests/acceptance/releases/canary-test.js
+++ b/tests/acceptance/releases/canary-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,22 @@ module('Acceptance | releases/canary', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/releases/canary');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/releases/canary');
+    await a11yAudit({
+      rules: {
+        'heading-order': {
+          enabled: false,
+        },
+        'scrollable-region-focusable': {
+          enabled: false,
+        },
+      },
+    });
 
     assert.ok(true);
   });

--- a/tests/acceptance/releases/lts-test.js
+++ b/tests/acceptance/releases/lts-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,19 @@ module('Acceptance | releases/lts', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/releases/lts');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/releases/lts');
+    await a11yAudit({
+      rules: {
+        'heading-order': {
+          enabled: false,
+        },
+      },
+    });
 
     assert.ok(true);
   });

--- a/tests/acceptance/releases/release-test.js
+++ b/tests/acceptance/releases/release-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,19 @@ module('Acceptance | releases/release', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/releases/release');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/releases/release');
+    await a11yAudit({
+      rules: {
+        'heading-order': {
+          enabled: false,
+        },
+      },
+    });
 
     assert.ok(true);
   });

--- a/tests/acceptance/security-test.js
+++ b/tests/acceptance/security-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,13 @@ module('Acceptance | security', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/security');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/security');
+    await a11yAudit();
 
     assert.ok(true);
   });

--- a/tests/acceptance/sponsors-test.js
+++ b/tests/acceptance/sponsors-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,22 @@ module('Acceptance | sponsors', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/sponsors');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/sponsors');
+    await a11yAudit({
+      rules: {
+        'link-name': {
+          enabled: false,
+        },
+        list: {
+          enabled: false,
+        },
+      },
+    });
 
     assert.ok(true);
   });

--- a/tests/acceptance/teams-test.js
+++ b/tests/acceptance/teams-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -9,6 +10,19 @@ module('Acceptance | teams', function (hooks) {
   test('Percy snapshot', async function (assert) {
     await visit('/teams');
     await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/teams');
+    await a11yAudit({
+      rules: {
+        'aria-valid-attr-value': {
+          enabled: false,
+        },
+      },
+    });
 
     assert.ok(true);
   });


### PR DESCRIPTION
## Background

Over the next month, I want to make several pull requests so that we can upgrade `ember-source` from `v3.20` to `v3.24`.


## Description

In this pull request, I added application tests that run an accessibility audit on each route.

To limit the scope of this pull request, when we violate an axe-recommended rule in a route, I made an exception to that rule in the corresponding test. We can address fixing the violation in a separate issue and pull request.