### PR TITLE
Added tests to better document the project (Part 5)

### DIFF
--- a/tests/acceptance/about/legal-test.js
+++ b/tests/acceptance/about/legal-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | about/legal', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/about/legal');
@@ -18,6 +20,6 @@ module('Acceptance | about/legal', function (hooks) {
     await visit('/about/legal');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle('Legal - Ember.js');
   });
 });

--- a/tests/acceptance/community-test.js
+++ b/tests/acceptance/community-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, skip } from 'qunit';
 
 module('Acceptance | community', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   /*
     TODO:
@@ -27,6 +29,6 @@ module('Acceptance | community', function (hooks) {
     await visit('/community');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle('Community - Ember.js');
   });
 });

--- a/tests/acceptance/community/black-lives-matter-test.js
+++ b/tests/acceptance/community/black-lives-matter-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, skip } from 'qunit';
 
 module('Acceptance | community/black lives matter', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   /*
     TODO:
@@ -27,6 +29,6 @@ module('Acceptance | community/black lives matter', function (hooks) {
     await visit('/community/black-lives-matter');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle('Community - Ember.js');
   });
 });

--- a/tests/acceptance/community/meetups-getting-started-test.js
+++ b/tests/acceptance/community/meetups-getting-started-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, skip } from 'qunit';
 
 module('Acceptance | community/meetups getting started', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   /*
     TODO:
@@ -27,6 +29,6 @@ module('Acceptance | community/meetups getting started', function (hooks) {
     await visit('/community/meetups-getting-started');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle('Getting Started - Ember.js');
   });
 });

--- a/tests/acceptance/community/meetups-test.js
+++ b/tests/acceptance/community/meetups-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, skip } from 'qunit';
 
 module('Acceptance | community/meetups', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   /*
     TODO:
@@ -27,6 +29,6 @@ module('Acceptance | community/meetups', function (hooks) {
     await visit('/community/meetups');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle('Meetups - Community - Ember.js');
   });
 });

--- a/tests/acceptance/community/meetups/assets-test.js
+++ b/tests/acceptance/community/meetups/assets-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | community/meetups/assets', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/community/meetups/assets');
@@ -18,6 +20,6 @@ module('Acceptance | community/meetups/assets', function (hooks) {
     await visit('/community/meetups/assets');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle('Assets - Community - Ember.js');
   });
 });

--- a/tests/acceptance/editions-test.js
+++ b/tests/acceptance/editions-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | editions', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/editions');
@@ -18,6 +20,6 @@ module('Acceptance | editions', function (hooks) {
     await visit('/editions');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle('Editions - Ember.js');
   });
 });

--- a/tests/acceptance/editions/octane-test.js
+++ b/tests/acceptance/editions/octane-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | editions/octane', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/editions/octane');
@@ -27,6 +29,6 @@ module('Acceptance | editions/octane', function (hooks) {
       },
     });
 
-    assert.ok(true);
+    assert.hasPageTitle('Octane - Editions - Ember.js');
   });
 });

--- a/tests/acceptance/ember-community-survey-2019-test.js
+++ b/tests/acceptance/ember-community-survey-2019-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, skip } from 'qunit';
 
 module('Acceptance | ember-community-survey-2019', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   /*
     TODO:
@@ -32,6 +34,6 @@ module('Acceptance | ember-community-survey-2019', function (hooks) {
     await visit('/ember-community-survey-2019');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle('Community Survey 2019 - Ember.js');
   });
 });

--- a/tests/acceptance/ember-users-test.js
+++ b/tests/acceptance/ember-users-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | ember-users', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/ember-users');
@@ -18,6 +20,6 @@ module('Acceptance | ember-users', function (hooks) {
     await visit('/ember-users');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle("Who's Using Ember.js - Ember.js");
   });
 });

--- a/tests/acceptance/guidelines-test.js
+++ b/tests/acceptance/guidelines-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | guidelines', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/guidelines');
@@ -18,6 +20,6 @@ module('Acceptance | guidelines', function (hooks) {
     await visit('/guidelines');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle('Community Guidelines - Ember.js');
   });
 });

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, skip } from 'qunit';
 
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   /*
     TODO:
@@ -33,6 +35,6 @@ module('Acceptance | index', function (hooks) {
       },
     });
 
-    assert.ok(true);
+    assert.hasPageTitle('Ember.js - A framework for ambitious web developers');
   });
 });

--- a/tests/acceptance/learn-test.js
+++ b/tests/acceptance/learn-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | learn', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/learn');
@@ -18,6 +20,6 @@ module('Acceptance | learn', function (hooks) {
     await visit('/learn');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle('Learn - Ember.js');
   });
 });

--- a/tests/acceptance/logos-test.js
+++ b/tests/acceptance/logos-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | logos', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/logos');
@@ -18,6 +20,6 @@ module('Acceptance | logos', function (hooks) {
     await visit('/logos');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle('Branding - Ember.js');
   });
 });

--- a/tests/acceptance/mascots-test.js
+++ b/tests/acceptance/mascots-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | mascots', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/mascots');
@@ -18,6 +20,6 @@ module('Acceptance | mascots', function (hooks) {
     await visit('/mascots');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle('Mascots - Ember.js');
   });
 });

--- a/tests/acceptance/mascots/commission-test.js
+++ b/tests/acceptance/mascots/commission-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | mascots/commission', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/mascots/commission');
@@ -27,6 +29,6 @@ module('Acceptance | mascots/commission', function (hooks) {
       },
     });
 
-    assert.ok(true);
+    assert.hasPageTitle('Ember.js');
   });
 });

--- a/tests/acceptance/mascots/faq-test.js
+++ b/tests/acceptance/mascots/faq-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | mascots/faq', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/mascots/faq');
@@ -18,6 +20,6 @@ module('Acceptance | mascots/faq', function (hooks) {
     await visit('/mascots/faq');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle('Ember.js');
   });
 });

--- a/tests/acceptance/mascots/payment-test.js
+++ b/tests/acceptance/mascots/payment-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | mascots/payment', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/mascots/payment');
@@ -24,6 +26,6 @@ module('Acceptance | mascots/payment', function (hooks) {
       },
     });
 
-    assert.ok(true);
+    assert.hasPageTitle('Ember.js');
   });
 });

--- a/tests/acceptance/releases-test.js
+++ b/tests/acceptance/releases-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | releases', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/releases');
@@ -27,6 +29,6 @@ module('Acceptance | releases', function (hooks) {
       },
     });
 
-    assert.ok(true);
+    assert.hasPageTitle('Releases - Ember.js');
   });
 });

--- a/tests/acceptance/releases/beta-test.js
+++ b/tests/acceptance/releases/beta-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | releases/beta', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/releases/beta');
@@ -24,6 +26,6 @@ module('Acceptance | releases/beta', function (hooks) {
       },
     });
 
-    assert.ok(true);
+    assert.hasPageTitle('Beta - Releases - Ember.js');
   });
 });

--- a/tests/acceptance/releases/canary-test.js
+++ b/tests/acceptance/releases/canary-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | releases/canary', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/releases/canary');
@@ -27,6 +29,6 @@ module('Acceptance | releases/canary', function (hooks) {
       },
     });
 
-    assert.ok(true);
+    assert.hasPageTitle('Canary - Releases - Ember.js');
   });
 });

--- a/tests/acceptance/releases/lts-test.js
+++ b/tests/acceptance/releases/lts-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | releases/lts', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/releases/lts');
@@ -24,6 +26,6 @@ module('Acceptance | releases/lts', function (hooks) {
       },
     });
 
-    assert.ok(true);
+    assert.hasPageTitle('LTS - Releases - Ember.js');
   });
 });

--- a/tests/acceptance/releases/release-test.js
+++ b/tests/acceptance/releases/release-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | releases/release', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/releases/release');
@@ -24,6 +26,6 @@ module('Acceptance | releases/release', function (hooks) {
       },
     });
 
-    assert.ok(true);
+    assert.hasPageTitle('Stable - Releases - Ember.js');
   });
 });

--- a/tests/acceptance/security-test.js
+++ b/tests/acceptance/security-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | security', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/security');
@@ -18,6 +20,6 @@ module('Acceptance | security', function (hooks) {
     await visit('/security');
     await a11yAudit();
 
-    assert.ok(true);
+    assert.hasPageTitle('Security - Ember.js');
   });
 });

--- a/tests/acceptance/sponsors-test.js
+++ b/tests/acceptance/sponsors-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | sponsors', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/sponsors');
@@ -27,6 +29,6 @@ module('Acceptance | sponsors', function (hooks) {
       },
     });
 
-    assert.ok(true);
+    assert.hasPageTitle('Sponsors - Ember.js');
   });
 });

--- a/tests/acceptance/teams-test.js
+++ b/tests/acceptance/teams-test.js
@@ -2,10 +2,12 @@ import { visit } from '@ember/test-helpers';
 import percySnapshot from '@percy/ember';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
 import { module, test } from 'qunit';
 
 module('Acceptance | teams', function (hooks) {
   setupApplicationTest(hooks);
+  setupPageTitleTest(hooks);
 
   test('Percy snapshot', async function (assert) {
     await visit('/teams');
@@ -24,6 +26,6 @@ module('Acceptance | teams', function (hooks) {
       },
     });
 
-    assert.ok(true);
+    assert.hasPageTitle('Team - Ember.js');
   });
 });

--- a/tests/helpers/page-title.js
+++ b/tests/helpers/page-title.js
@@ -1,0 +1,36 @@
+export function setupPageTitleTest(hooks) {
+  hooks.beforeEach(setUpCustomAssertions);
+  hooks.afterEach(cleanUpCustomAssertions);
+}
+
+/*
+  Based on https://github.com/ember-cli/ember-page-title/blob/f8fff84c142aab9b661e395c1586110fdda495f2/tests/helpers/get-page-title.js
+*/
+function setUpCustomAssertions(assert) {
+  assert.hasPageTitle = (expectedValue) => {
+    const titleElement = [
+      ...window.document.querySelectorAll('head title'),
+    ].pop();
+
+    if (!titleElement) {
+      assert.ok(false, 'Error: The <title> element could not be found.');
+
+      return;
+    }
+
+    // Remove progress check, e.g. `(5/5)`, that Testem appends to the title
+    const actualValue = titleElement.innerText
+      .trim()
+      .replace(/^\(\d+\/\d+\)/, '');
+
+    assert.strictEqual(
+      actualValue,
+      expectedValue,
+      'We render the correct page title.'
+    );
+  };
+}
+
+function cleanUpCustomAssertions(assert) {
+  delete assert.hasPageTitle;
+}


### PR DESCRIPTION
## Background

A new Ember 3.24 app will have `ember-page-title` installed. The `ember-website` app already uses `ember-page-title`, but the installed addon is 1 major version behind.

Before we upgrade `ember-page-title` to `v6.x`, we must consider:

- Replacing the `{{title}}` helper with `{{page-title}}` helper
- Updating `app/templates/head.hbs` (the template mentions a `<title>` element)


## Description

To help with replacing the `{{title}}` helper with `{{page-title}}` with confidence, I added assertions for each route that we already test. The custom assertion is based on [the one from `ember-page-title`](https://github.com/ember-cli/ember-page-title/blob/f8fff84c142aab9b661e395c1586110fdda495f2/tests/helpers/get-page-title.js).

In general, it probably isn't a good idea to test an external addon (we should assume that they work as intended). In this case, since upgrading `ember-page-title` can result in a breaking change, I think it's okay to keep the assertions around. We can always remove the assertions after they have served their purpose.