### PR TITLE
Replace deprecated title helper to page-title

### DIFF
--- a/app/templates/about/legal.hbs
+++ b/app/templates/about/legal.hbs
@@ -1,4 +1,4 @@
-{{title "Legal"}}
+{{page-title "Legal"}}
 <section class="container" aria-labelledby="legal">
   <h1 id="legal">Legal</h1>
   <p>

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,5 +1,5 @@
 <HeadLayout />
-{{title "Ember.js"}}
+{{page-title "Ember.js"}}
 
 <BlackLivesMatterBanner />
 <EmberSurvey />

--- a/app/templates/community.hbs
+++ b/app/templates/community.hbs
@@ -1,3 +1,3 @@
-{{title "Community"}}
+{{page-title "Community"}}
 
 {{outlet}}

--- a/app/templates/community/meetups-getting-started.hbs
+++ b/app/templates/community/meetups-getting-started.hbs
@@ -1,4 +1,4 @@
-{{title "Getting Started"}}
+{{page-title "Getting Started"}}
 <section class="container" aria-labelledby="getting-your-meetup-up-and-running">
   <h1 id="getting-your-meetup-up-and-running">
     Getting Your Meetup Up and Running

--- a/app/templates/community/meetups/assets.hbs
+++ b/app/templates/community/meetups/assets.hbs
@@ -1,4 +1,4 @@
-{{title "Assets"}}
+{{page-title "Assets"}}
 <section class="container" aria-labelledby="ember-meetup-resources">
   <h1 id="ember-meetup-resources">
     Ember Meetup Resources

--- a/app/templates/community/meetups/index.hbs
+++ b/app/templates/community/meetups/index.hbs
@@ -1,4 +1,4 @@
-{{title "Meetups"}}
+{{page-title "Meetups"}}
 <div class="container">
   <h1 class="mb-3">Meetups Around the World</h1>
 

--- a/app/templates/editions/index.hbs
+++ b/app/templates/editions/index.hbs
@@ -1,4 +1,4 @@
-{{title "Editions"}}
+{{page-title "Editions"}}
 <section class="container" aria-labelledby="ember-editions">
   <h1 id="ember-editions">Ember Editions</h1>
   <p>

--- a/app/templates/editions/octane.hbs
+++ b/app/templates/editions/octane.hbs
@@ -1,5 +1,5 @@
-{{title "Editions"}}
-{{title "Octane"}}
+{{page-title "Editions"}}
+{{page-title "Octane"}}
 
 <section class="container" aria-labelledby="octane-edition">
   <h1>The Octane Edition of Ember</h1>

--- a/app/templates/ember-community-survey-2016.hbs
+++ b/app/templates/ember-community-survey-2016.hbs
@@ -1,4 +1,4 @@
-{{title "Community Survey 2016"}}
+{{page-title "Community Survey 2016"}}
 <div class="bg-dark bg-shape-boxes">
   <div class="container survey-header survey-container">
 

--- a/app/templates/ember-community-survey-2017.hbs
+++ b/app/templates/ember-community-survey-2017.hbs
@@ -1,4 +1,4 @@
-{{title "Community Survey 2017"}}
+{{page-title "Community Survey 2017"}}
 <div class="bg-dark bg-shape-boxes">
   <div class="container">
 

--- a/app/templates/ember-community-survey-2018.hbs
+++ b/app/templates/ember-community-survey-2018.hbs
@@ -1,4 +1,4 @@
-{{title "Community Survey 2018"}}
+{{page-title "Community Survey 2018"}}
 <div class="bg-dark bg-shape-boxes">
   <div class="container">
 

--- a/app/templates/ember-community-survey-2019.hbs
+++ b/app/templates/ember-community-survey-2019.hbs
@@ -1,4 +1,4 @@
-{{title "Community Survey 2019"}}
+{{page-title "Community Survey 2019"}}
 <div class="bg-dark bg-shape-boxes">
   <div class="container">
     <h1>

--- a/app/templates/ember-community-survey-2020.hbs
+++ b/app/templates/ember-community-survey-2020.hbs
@@ -1,4 +1,4 @@
-{{title "Community Survey 2020"}}
+{{page-title "Community Survey 2020"}}
 
 <div class="bg-dark bg-shape-boxes">
   <div class="container">

--- a/app/templates/ember-users.hbs
+++ b/app/templates/ember-users.hbs
@@ -1,4 +1,4 @@
-{{title "Who's Using Ember.js"}}
+{{page-title "Who's Using Ember.js"}}
 <section class="container" aria-labelledby="ember-users">
   <div class="layout">
     <div class="lg:col-4 lg:start-2 text-center text-muted mb-5">

--- a/app/templates/guidelines.hbs
+++ b/app/templates/guidelines.hbs
@@ -1,4 +1,4 @@
-{{title "Community Guidelines"}}
+{{page-title "Community Guidelines"}}
 <div class="container layout">
   <section class="lg:col-5" aria-labelledby="guidelines">
     <h1 id="guidelines">Ember Community Guidelines</h1>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,4 +1,4 @@
-{{title "Ember.js - A framework for ambitious web developers" replace=true}}
+{{page-title "Ember.js - A framework for ambitious web developers" replace=true}}
 
 <section aria-labelledby="hero-title" class="bg-shape-boxes-bottom bg-dark">
   <div class="container layout">

--- a/app/templates/learn/index.hbs
+++ b/app/templates/learn/index.hbs
@@ -1,4 +1,4 @@
-{{title "Learn"}}
+{{page-title "Learn"}}
 <div class="container" aria-labelledby="learning-emberjs">
   <h1 id="learning-emberjs">Learning Ember.js</h1>
 

--- a/app/templates/logos.hbs
+++ b/app/templates/logos.hbs
@@ -1,4 +1,4 @@
-{{title "Branding"}}
+{{page-title "Branding"}}
 <div class="container">
   <h1>Branding</h1>
 

--- a/app/templates/mascots/index.hbs
+++ b/app/templates/mascots/index.hbs
@@ -1,4 +1,4 @@
-{{title "Mascots"}}
+{{page-title "Mascots"}}
 <section aria-label="Mascots" class="container">
   <h1>Tomster and Zoey</h1>
   <p>

--- a/app/templates/releases.hbs
+++ b/app/templates/releases.hbs
@@ -1,4 +1,4 @@
-{{title "Releases"}}
+{{page-title "Releases"}}
 <div class="container">
   {{outlet}}
 </div>

--- a/app/templates/releases/beta.hbs
+++ b/app/templates/releases/beta.hbs
@@ -1,4 +1,4 @@
-{{title "Beta"}}
+{{page-title "Beta"}}
 
 <ProjectListing
     @channel="beta"

--- a/app/templates/releases/canary.hbs
+++ b/app/templates/releases/canary.hbs
@@ -1,4 +1,4 @@
-{{title "Canary"}}
+{{page-title "Canary"}}
 
 <h1 class="project-name">{{capitalize "canary"}} Channel</h1>
 

--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -1,4 +1,4 @@
-{{title "LTS"}}
+{{page-title "LTS"}}
 
 <ProjectListing
   @projects={{array @model}}

--- a/app/templates/releases/release.hbs
+++ b/app/templates/releases/release.hbs
@@ -1,4 +1,4 @@
-{{title "Stable"}}
+{{page-title "Stable"}}
 
 <ProjectListing
   @projects={{array @model.ember @model.emberData}}

--- a/app/templates/security.hbs
+++ b/app/templates/security.hbs
@@ -1,4 +1,4 @@
-{{title "Security"}}
+{{page-title "Security"}}
 <div class="container layout">
   <section class="lg:col-5" aria-labelledby="section-reporting-a-bug">
     <h1>Ember.js Security Policy</h1>

--- a/app/templates/sponsors.hbs
+++ b/app/templates/sponsors.hbs
@@ -1,4 +1,4 @@
-{{title "Sponsors"}}
+{{page-title "Sponsors"}}
 <section class="container" aria-labelledby="ember-sponsors-and-friends">
   <h1 id="ember-sponsors-and-friends">
     Ember Sponsors and Friends

--- a/app/templates/team.hbs
+++ b/app/templates/team.hbs
@@ -1,4 +1,4 @@
-{{title "Team"}}
+{{page-title "Team"}}
 <div class="container">
   <h1 class="text-center">The Team Behind Ember</h1>
   <section class="mb-3" aria-labelledby="team-detail">


### PR DESCRIPTION
Resolves https://github.com/ember-learn/ember-website/issues/711
### Notes
According to https://github.com/ember-cli/ember-page-title#upgrading-notes-for-5x-to-6x I had to remove usage of `HeadLayout` from `application.hbs`