### PR TITLE
Extracted replaceLinks from the application controller

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,42 +1,7 @@
 import Controller from '@ember/controller';
 import styleguideLinks from 'ember-styleguide/constants/links';
 import { infoLinks } from 'ember-styleguide/constants/es-footer';
-
-function replaceUrlPrefix(url) {
-  // ignore external apps
-  if (
-    url.endsWith('/blog') ||
-    url.endsWith('/deprecations') ||
-    url.endsWith('/api')
-  ) {
-    return url;
-  }
-
-  return url
-    .replace(/^https:\/\/emberjs.com\//, '/')
-    .replace(/^\/builds(\/\w+)$/, '/releases$1')
-    .replace(/\/builds$/, '/releases');
-}
-
-function replaceLinks(links) {
-  return links.map((group) => {
-    if (group.items) {
-      return {
-        ...group,
-        items: replaceLinks(group.items),
-      };
-    }
-
-    if (group.href) {
-      return {
-        ...group,
-        href: replaceUrlPrefix(group.href),
-      };
-    }
-
-    return group;
-  });
-}
+import replaceLinks from 'ember-website/utils/replace-links';
 
 export default Controller.extend({
   links: replaceLinks(styleguideLinks),

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
-import styleguideLinks from 'ember-styleguide/constants/links';
 import { infoLinks } from 'ember-styleguide/constants/es-footer';
+import styleguideLinks from 'ember-styleguide/constants/links';
 import replaceLinks from 'ember-website/utils/replace-links';
 
 export default Controller.extend({

--- a/app/utils/replace-links.js
+++ b/app/utils/replace-links.js
@@ -1,0 +1,35 @@
+function replaceUrlPrefix(url) {
+  // ignore external apps
+  if (
+    url.endsWith('/blog') ||
+    url.endsWith('/deprecations') ||
+    url.endsWith('/api')
+  ) {
+    return url;
+  }
+
+  return url
+    .replace(/^https:\/\/emberjs.com\//, '/')
+    .replace(/^\/builds(\/\w+)$/, '/releases$1')
+    .replace(/\/builds$/, '/releases');
+}
+
+export default function replaceLinks(links) {
+  return links.map((group) => {
+    if (group.items) {
+      return {
+        ...group,
+        items: replaceLinks(group.items),
+      };
+    }
+
+    if (group.href) {
+      return {
+        ...group,
+        href: replaceUrlPrefix(group.href),
+      };
+    }
+
+    return group;
+  });
+}

--- a/app/utils/replace-links.js
+++ b/app/utils/replace-links.js
@@ -4,8 +4,15 @@ const legacyExternalLinks = new Set([
   'https://emberjs.com/deprecations',
 ]);
 
+function isExternalLink(url) {
+  const isExternalLink = !url.startsWith('https://emberjs.com');
+  const isLegacyExternalLink = legacyExternalLinks.has(url);
+
+  return isExternalLink || isLegacyExternalLink;
+}
+
 function replaceUrlPrefix(url) {
-  if (legacyExternalLinks.has(url)) {
+  if (isExternalLink(url)) {
     return url;
   }
 

--- a/app/utils/replace-links.js
+++ b/app/utils/replace-links.js
@@ -11,11 +11,12 @@ function isExternalLink(url) {
   return isExternalLink || isLegacyExternalLink;
 }
 
-function replaceUrlPrefix(url) {
+function replaceInternalLinks(url) {
   if (isExternalLink(url)) {
     return url;
   }
 
+  // Map internal links to the correct route name
   return url
     .replace(/^https:\/\/emberjs.com\//, '/')
     .replace(/^\/builds(\/\w+)$/, '/releases$1')
@@ -34,7 +35,7 @@ export default function replaceLinks(links) {
     if (group.href) {
       return {
         ...group,
-        href: replaceUrlPrefix(group.href),
+        href: replaceInternalLinks(group.href),
       };
     }
 

--- a/app/utils/replace-links.js
+++ b/app/utils/replace-links.js
@@ -1,10 +1,11 @@
+const legacyExternalLinks = new Set([
+  'https://emberjs.com/api',
+  'https://emberjs.com/blog',
+  'https://emberjs.com/deprecations',
+]);
+
 function replaceUrlPrefix(url) {
-  // ignore external apps
-  if (
-    url.endsWith('/blog') ||
-    url.endsWith('/deprecations') ||
-    url.endsWith('/api')
-  ) {
+  if (legacyExternalLinks.has(url)) {
     return url;
   }
 

--- a/tests/unit/utils/replace-links-test.js
+++ b/tests/unit/utils/replace-links-test.js
@@ -1,0 +1,703 @@
+import replaceLinks from 'ember-website/utils/replace-links';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | replace-links', function () {
+  test('replaces URLs that begin with https://emberjs.com with internal route names', function (assert) {
+    /*
+      These are the links that we currently display in the header (as of October 7, 2020).
+      Note that none of the URLs includes the word "builds" now.
+
+      See https://github.com/ember-learn/ember-styleguide/blob/ab1d1fc32dd023f287c49d3fd700216ba368771a/addon/constants/links.js
+    */
+    const links = [
+      {
+        name: 'Docs',
+        type: 'dropdown',
+        items: [
+          {
+            href: 'https://guides.emberjs.com',
+            name: 'Ember.js Guides',
+            type: 'link',
+          },
+          {
+            href: 'https://api.emberjs.com',
+            name: 'API Reference',
+            type: 'link',
+          },
+          {
+            href: 'https://cli.emberjs.com',
+            name: 'CLI Guides',
+            type: 'link',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            href: 'https://emberjs.com/learn',
+            name: 'Learn Ember',
+            type: 'link',
+          },
+        ],
+      },
+      {
+        name: 'Releases',
+        type: 'dropdown',
+        items: [
+          {
+            href: 'https://emberjs.com/releases',
+            name: 'Overview',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/releases/lts',
+            name: '→ LTS',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/releases/release',
+            name: '→ Stable',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/releases/beta',
+            name: '→ Beta',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/releases/canary',
+            name: '→ Canary',
+            type: 'link',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            href: 'https://emberjs.com/editions',
+            name: 'Editions',
+            type: 'link',
+          },
+          {
+            href: 'https://deprecations.emberjs.com',
+            name: 'Deprecations',
+            type: 'link',
+          },
+          {
+            href: 'https://github.com/emberjs/rfc-tracking/issues',
+            name: 'RFC Tracking',
+            type: 'link',
+          },
+        ],
+      },
+      {
+        href: 'https://blog.emberjs.com',
+        name: 'Blog',
+        type: 'link',
+      },
+      {
+        name: 'Community',
+        type: 'dropdown',
+        items: [
+          {
+            href: 'https://emberjs.com/community',
+            name: 'The Ember Community',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/guidelines',
+            name: 'Guidelines',
+            type: 'link',
+          },
+          {
+            href: 'https://help-wanted.emberjs.com/',
+            name: 'Help Wanted',
+            type: 'link',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            href: 'https://emberjs.com/community/meetups',
+            name: 'Meetups',
+            type: 'link',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            href: 'http://emberconf.com/',
+            name: 'Ember Conf',
+            type: 'link',
+          },
+        ],
+      },
+      {
+        name: 'About',
+        type: 'dropdown',
+        items: [
+          {
+            href: 'https://emberjs.com/team',
+            name: 'The Team',
+            type: 'link',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            href: 'https://emberjs.com/logos',
+            name: 'Branding',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/mascots',
+            name: 'Mascots',
+            type: 'link',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            href: 'https://emberjs.com/ember-users',
+            name: 'Who Uses Ember',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/sponsors',
+            name: 'Sponsors',
+            type: 'link',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            href: 'https://emberjs.com/about/legal',
+            name: 'Legal',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/security',
+            name: 'Security',
+            type: 'link',
+          },
+        ],
+      },
+    ];
+
+    const output = replaceLinks(links);
+
+    assert.deepEqual(
+      output,
+      [
+        {
+          name: 'Docs',
+          type: 'dropdown',
+          items: [
+            {
+              href: 'https://guides.emberjs.com',
+              name: 'Ember.js Guides',
+              type: 'link',
+            },
+            {
+              href: 'https://api.emberjs.com',
+              name: 'API Reference',
+              type: 'link',
+            },
+            {
+              href: 'https://cli.emberjs.com',
+              name: 'CLI Guides',
+              type: 'link',
+            },
+            {
+              type: 'divider',
+            },
+            {
+              href: '/learn',
+              name: 'Learn Ember',
+              type: 'link',
+            },
+          ],
+        },
+        {
+          name: 'Releases',
+          type: 'dropdown',
+          items: [
+            {
+              href: '/releases',
+              name: 'Overview',
+              type: 'link',
+            },
+            {
+              href: '/releases/lts',
+              name: '→ LTS',
+              type: 'link',
+            },
+            {
+              href: '/releases/release',
+              name: '→ Stable',
+              type: 'link',
+            },
+            {
+              href: '/releases/beta',
+              name: '→ Beta',
+              type: 'link',
+            },
+            {
+              href: '/releases/canary',
+              name: '→ Canary',
+              type: 'link',
+            },
+            {
+              type: 'divider',
+            },
+            {
+              href: '/editions',
+              name: 'Editions',
+              type: 'link',
+            },
+            {
+              href: 'https://deprecations.emberjs.com',
+              name: 'Deprecations',
+              type: 'link',
+            },
+            {
+              href: 'https://github.com/emberjs/rfc-tracking/issues',
+              name: 'RFC Tracking',
+              type: 'link',
+            },
+          ],
+        },
+        {
+          href: 'https://blog.emberjs.com',
+          name: 'Blog',
+          type: 'link',
+        },
+        {
+          name: 'Community',
+          type: 'dropdown',
+          items: [
+            {
+              href: '/community',
+              name: 'The Ember Community',
+              type: 'link',
+            },
+            {
+              href: '/guidelines',
+              name: 'Guidelines',
+              type: 'link',
+            },
+            {
+              href: 'https://help-wanted.emberjs.com/',
+              name: 'Help Wanted',
+              type: 'link',
+            },
+            {
+              type: 'divider',
+            },
+            {
+              href: '/community/meetups',
+              name: 'Meetups',
+              type: 'link',
+            },
+            {
+              type: 'divider',
+            },
+            {
+              href: 'http://emberconf.com/',
+              name: 'Ember Conf',
+              type: 'link',
+            },
+          ],
+        },
+        {
+          name: 'About',
+          type: 'dropdown',
+          items: [
+            {
+              href: '/team',
+              name: 'The Team',
+              type: 'link',
+            },
+            {
+              type: 'divider',
+            },
+            {
+              href: '/logos',
+              name: 'Branding',
+              type: 'link',
+            },
+            {
+              href: '/mascots',
+              name: 'Mascots',
+              type: 'link',
+            },
+            {
+              type: 'divider',
+            },
+            {
+              href: '/ember-users',
+              name: 'Who Uses Ember',
+              type: 'link',
+            },
+            {
+              href: '/sponsors',
+              name: 'Sponsors',
+              type: 'link',
+            },
+            {
+              type: 'divider',
+            },
+            {
+              href: '/about/legal',
+              name: 'Legal',
+              type: 'link',
+            },
+            {
+              href: '/security',
+              name: 'Security',
+              type: 'link',
+            },
+          ],
+        },
+      ],
+      'We get the correct output.'
+    );
+  });
+
+  test('it works when we used to have the word "builds" in the URL', function (assert) {
+    /*
+      These are the links that we used to display in the header (on June 19, 2018).
+
+      See https://github.com/ember-learn/ember-website/blob/d08e34a0acd403d16ee78c90ec0ec368762e3e9f/app/links.js
+    */
+    const links = [
+      {
+        name: 'Docs',
+        type: 'dropdown',
+        items: [
+          {
+            href: 'https://guides.emberjs.com',
+            name: 'Guides',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/api',
+            name: 'API Reference',
+            type: 'link',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            href: 'https://emberjs.com/learn',
+            name: 'Learn Ember',
+            type: 'link',
+          },
+        ],
+      },
+      {
+        name: 'Releases',
+        type: 'dropdown',
+        items: [
+          {
+            href: 'https://emberjs.com/builds',
+            name: 'Channels',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/builds/release',
+            name: '-- Stable',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/builds/beta',
+            name: '-- Beta',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/builds/canary',
+            name: '-- Canary',
+            type: 'link',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            href: 'https://emberjs.com/deprecations',
+            name: 'Deprecations',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/statusboard',
+            name: 'Status Board',
+            type: 'link',
+          },
+        ],
+      },
+      {
+        href: 'https://emberjs.com/blog',
+        name: 'Blog',
+        type: 'link',
+      },
+      {
+        name: 'Community',
+        type: 'dropdown',
+        items: [
+          {
+            href: 'https://emberjs.com/community',
+            name: 'The Ember Community',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/guidelines',
+            name: 'Guidelines',
+            type: 'link',
+          },
+          {
+            href: 'http://github.com/emberjs/',
+            name: 'Contribute (Github)',
+            type: 'link',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            href: 'https://emberjs.com/community/meetups',
+            name: 'Meetups',
+            type: 'link',
+          },
+          {
+            href: 'http://jobs.emberjs.com/',
+            name: 'Job Board',
+            type: 'link',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            href: 'http://emberconf.com/',
+            name: 'Ember Conf',
+            type: 'link',
+          },
+        ],
+      },
+      {
+        name: 'About',
+        type: 'dropdown',
+        items: [
+          {
+            href: 'https://emberjs.com/team',
+            name: 'The Team',
+            type: 'link',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            href: 'https://emberjs.com/logos',
+            name: 'Logos',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/mascots',
+            name: 'Mascots',
+            type: 'link',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            href: 'https://emberjs.com/ember-users',
+            name: 'Who Uses Ember',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/sponsors',
+            name: 'Sponsors',
+            type: 'link',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            href: 'https://emberjs.com/legal',
+            name: 'Legal',
+            type: 'link',
+          },
+          {
+            href: 'https://emberjs.com/security',
+            name: 'Security',
+            type: 'link',
+          },
+        ],
+      },
+    ];
+
+    const output = replaceLinks(links);
+
+    assert.deepEqual(
+      output,
+      [
+        {
+          name: 'Docs',
+          type: 'dropdown',
+          items: [
+            {
+              href: 'https://guides.emberjs.com',
+              name: 'Guides',
+              type: 'link',
+            },
+            {
+              href: 'https://emberjs.com/api',
+              name: 'API Reference',
+              type: 'link',
+            },
+            {
+              type: 'divider',
+            },
+            {
+              href: '/learn',
+              name: 'Learn Ember',
+              type: 'link',
+            },
+          ],
+        },
+        {
+          name: 'Releases',
+          type: 'dropdown',
+          items: [
+            {
+              href: '/releases',
+              name: 'Channels',
+              type: 'link',
+            },
+            {
+              href: '/releases/release',
+              name: '-- Stable',
+              type: 'link',
+            },
+            {
+              href: '/releases/beta',
+              name: '-- Beta',
+              type: 'link',
+            },
+            {
+              href: '/releases/canary',
+              name: '-- Canary',
+              type: 'link',
+            },
+            {
+              type: 'divider',
+            },
+            {
+              href: 'https://emberjs.com/deprecations',
+              name: 'Deprecations',
+              type: 'link',
+            },
+            {
+              href: '/statusboard',
+              name: 'Status Board',
+              type: 'link',
+            },
+          ],
+        },
+        {
+          href: 'https://emberjs.com/blog',
+          name: 'Blog',
+          type: 'link',
+        },
+        {
+          name: 'Community',
+          type: 'dropdown',
+          items: [
+            {
+              href: '/community',
+              name: 'The Ember Community',
+              type: 'link',
+            },
+            {
+              href: '/guidelines',
+              name: 'Guidelines',
+              type: 'link',
+            },
+            {
+              href: 'http://github.com/emberjs/',
+              name: 'Contribute (Github)',
+              type: 'link',
+            },
+            {
+              type: 'divider',
+            },
+            {
+              href: '/community/meetups',
+              name: 'Meetups',
+              type: 'link',
+            },
+            {
+              href: 'http://jobs.emberjs.com/',
+              name: 'Job Board',
+              type: 'link',
+            },
+            {
+              type: 'divider',
+            },
+            {
+              href: 'http://emberconf.com/',
+              name: 'Ember Conf',
+              type: 'link',
+            },
+          ],
+        },
+        {
+          name: 'About',
+          type: 'dropdown',
+          items: [
+            {
+              href: '/team',
+              name: 'The Team',
+              type: 'link',
+            },
+            {
+              type: 'divider',
+            },
+            {
+              href: '/logos',
+              name: 'Logos',
+              type: 'link',
+            },
+            {
+              href: '/mascots',
+              name: 'Mascots',
+              type: 'link',
+            },
+            {
+              type: 'divider',
+            },
+            {
+              href: '/ember-users',
+              name: 'Who Uses Ember',
+              type: 'link',
+            },
+            {
+              href: '/sponsors',
+              name: 'Sponsors',
+              type: 'link',
+            },
+            {
+              type: 'divider',
+            },
+            {
+              href: '/legal',
+              name: 'Legal',
+              type: 'link',
+            },
+            {
+              href: '/security',
+              name: 'Security',
+              type: 'link',
+            },
+          ],
+        },
+      ],
+      'We get the correct output.'
+    );
+  });
+});


### PR DESCRIPTION
## Background

Over the next month, we'll upgrade `ember-source` from `v3.20` to `v3.24` and ensure that we follow recommended practices in Ember Octane.


## Description

In this pull request, I extracted the function `replaceLinks` from the `application` controller to a utility file called `replace-links`.

This way, we can write unit tests to document what `replaceLinks` is supposed to do, and help a contributor easily rewrite the `application` controller in native class.


## How to Review

I made a few refactors so I recommend reviewing the commits one by one.