### PR TITLE
Added tests to better document the project (Part 7)

### DIFF
--- a/app/controllers/community/meetups/index.js
+++ b/app/controllers/community/meetups/index.js
@@ -12,6 +12,10 @@ export default Controller.extend({
 
     if (!this.fastboot?.isFastBoot) {
       import('leaflet').then(() => {
+        if (this.isDestroyed || this.isDestroying) {
+          return;
+        }
+
         let prefix = '';
         const config = getOwner(this).resolveRegistration('config:environment');
 
@@ -26,6 +30,6 @@ export default Controller.extend({
   lng: 0,
   zoom: 2,
   meetupsByArea: groupBy('model', 'area'),
-  sortingKeys: Object.freeze(['items.length:desc']),
+  sortingKeys: Object.freeze(['items.length:desc', 'value:asc']),
   sortedMeetupsByArea: sort('meetupsByArea', 'sortingKeys'),
 });

--- a/app/controllers/learn/index.js
+++ b/app/controllers/learn/index.js
@@ -1,7 +1,0 @@
-import Controller from '@ember/controller';
-import { sort } from '@ember/object/computed';
-
-export default Controller.extend({
-  sortingKey: Object.freeze(['id']),
-  sortedModel: sort('model', 'sortingKey'),
-});

--- a/app/controllers/releases/index.js
+++ b/app/controllers/releases/index.js
@@ -5,14 +5,4 @@ export default Controller.extend({
   emberBetaProject: computed('model.@each.isEmberBeta', function () {
     return this.model.find((p) => p.isEmberBeta);
   }),
-  emberReleaseProject: computed('model.@each.{channel,name}', function () {
-    return this.model.find((p) => {
-      return p.get('channel') === 'release' && p.get('name') === 'Ember';
-    });
-  }),
-  emberLTSProject: computed('model.@each.{channel,name}', function () {
-    return this.model.find((p) => {
-      return p.get('channel') === 'lts' && p.get('name') === 'Ember';
-    });
-  }),
 });

--- a/app/controllers/releases/index.js
+++ b/app/controllers/releases/index.js
@@ -2,7 +2,9 @@ import { computed } from '@ember/object';
 import Controller from '@ember/controller';
 
 export default Controller.extend({
-  emberBetaProject: computed('model.@each.isEmberBeta', function () {
-    return this.model.find((p) => p.isEmberBeta);
+  emberBetaProject: computed('model.@each.{name,channel}', function () {
+    return this.model.find((project) => {
+      return project.name === 'Ember' && project.channel === 'beta';
+    });
   }),
 });

--- a/app/controllers/team.js
+++ b/app/controllers/team.js
@@ -9,7 +9,7 @@ function inTeam(team) {
 }
 
 export default Controller.extend({
-  sortingKeys: Object.freeze(['added']),
+  sortingKeys: Object.freeze(['last', 'first']),
   sortedModel: sort('model', 'sortingKeys'),
 
   alumniTeamMembers: inTeam('alumni'),

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -18,10 +18,6 @@ export default class ProjectModel extends Model {
   @attr('date') nextDate;
   @attr('string') repo;
 
-  get isEmberBeta() {
-    return this.channel === 'beta' && this.name === 'Ember';
-  }
-
   get lastReleaseChangelogUrl() {
     if (this.channel === 'canary' || !this.changelogPath) {
       return '';

--- a/tests/unit/controllers/application-test.js
+++ b/tests/unit/controllers/application-test.js
@@ -1,0 +1,13 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Controller | application', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    const controller = this.owner.lookup('controller:application');
+
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/controllers/community/meetups/index-test.js
+++ b/tests/unit/controllers/community/meetups/index-test.js
@@ -1,0 +1,140 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupTest } from 'ember-qunit';
+import meetups from 'ember-website/mirage/data/meetups';
+import { module, test } from 'qunit';
+
+module('Unit | Controller | community/meetups/index', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    // Create Meetup data
+    this.server.db.loadData({ meetups });
+
+    // Run model hook
+    const store = this.owner.lookup('service:store');
+    const model = await store.findAll('meetup');
+
+    // Run setupController hook
+    this.controller = this.owner.lookup('controller:community/meetups/index');
+    this.controller.model = model;
+  });
+
+  test('We group Meetups by area', function (assert) {
+    const { meetupsByArea } = this.controller;
+
+    // Create an intermediate data structure for assertion
+    const output = meetupsByArea.reduce((accumulator, group) => {
+      const area = group.value;
+      const meetupIds = group.items.map((meetup) => meetup.id);
+
+      accumulator.push({
+        area,
+        meetupIds,
+      });
+
+      return accumulator;
+    }, []);
+
+    assert.deepEqual(
+      output,
+      [
+        {
+          area: 'North America',
+          meetupIds: [
+            'austin-tx',
+            'new-york-ny',
+            'portland-or',
+            'seattle-wa',
+            'toronto-on',
+          ],
+        },
+        {
+          area: 'South America',
+          meetupIds: ['belo-horizonte-brazil', 'santiago-chile'],
+        },
+        {
+          area: 'Europe',
+          meetupIds: [
+            'berlin-germany',
+            'madrid-spain',
+            'nizhny-novgorod-russia',
+            'zurich-switzerland',
+          ],
+        },
+        {
+          area: 'Africa',
+          meetupIds: ['cape-town-south-africa'],
+        },
+        {
+          area: 'Asia',
+          meetupIds: ['chennai-india', 'tel-aviv-israel'],
+        },
+        {
+          area: 'Oceania',
+          meetupIds: ['wellington-new-zealand'],
+        },
+      ],
+      'We get the correct output.'
+    );
+  });
+
+  test('We sort areas by how many Meetups they have', function (assert) {
+    const { sortedMeetupsByArea } = this.controller;
+
+    // Create an intermediate data structure for assertion
+    const output = sortedMeetupsByArea.reduce((accumulator, group) => {
+      const area = group.value;
+      const meetupIds = group.items.map((meetup) => meetup.id);
+
+      accumulator.push({
+        area,
+        meetupIds,
+      });
+
+      return accumulator;
+    }, []);
+
+    assert.deepEqual(
+      output,
+      [
+        {
+          area: 'North America',
+          meetupIds: [
+            'austin-tx',
+            'new-york-ny',
+            'portland-or',
+            'seattle-wa',
+            'toronto-on',
+          ],
+        },
+        {
+          area: 'Europe',
+          meetupIds: [
+            'berlin-germany',
+            'madrid-spain',
+            'nizhny-novgorod-russia',
+            'zurich-switzerland',
+          ],
+        },
+        {
+          area: 'Asia',
+          meetupIds: ['chennai-india', 'tel-aviv-israel'],
+        },
+        {
+          area: 'South America',
+          meetupIds: ['belo-horizonte-brazil', 'santiago-chile'],
+        },
+        {
+          area: 'Africa',
+          meetupIds: ['cape-town-south-africa'],
+        },
+        {
+          area: 'Oceania',
+          meetupIds: ['wellington-new-zealand'],
+        },
+      ],
+      'We get the correct output.'
+    );
+  });
+});

--- a/tests/unit/controllers/ember-community-survey-2016-test.js
+++ b/tests/unit/controllers/ember-community-survey-2016-test.js
@@ -1,0 +1,15 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Controller | ember-community-survey-2016', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    const controller = this.owner.lookup(
+      'controller:ember-community-survey-2016'
+    );
+
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/controllers/ember-community-survey-2017-test.js
+++ b/tests/unit/controllers/ember-community-survey-2017-test.js
@@ -1,0 +1,15 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Controller | ember-community-survey-2017', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    const controller = this.owner.lookup(
+      'controller:ember-community-survey-2017'
+    );
+
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/controllers/ember-community-survey-2018-test.js
+++ b/tests/unit/controllers/ember-community-survey-2018-test.js
@@ -1,0 +1,15 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Controller | ember-community-survey-2018', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    const controller = this.owner.lookup(
+      'controller:ember-community-survey-2018'
+    );
+
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/controllers/ember-community-survey-2019-test.js
+++ b/tests/unit/controllers/ember-community-survey-2019-test.js
@@ -1,0 +1,15 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Controller | ember-community-survey-2019', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    const controller = this.owner.lookup(
+      'controller:ember-community-survey-2019'
+    );
+
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/controllers/ember-users-test.js
+++ b/tests/unit/controllers/ember-users-test.js
@@ -1,0 +1,44 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupTest } from 'ember-qunit';
+import users from 'ember-website/mirage/data/users';
+import { module, test } from 'qunit';
+
+module('Unit | Controller | ember-users', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    // Create Meetup data
+    this.server.db.loadData({ users });
+
+    // Run model hook
+    const store = this.owner.lookup('service:store');
+    const model = await store.findAll('user');
+
+    // Run setupController hook
+    this.controller = this.owner.lookup('controller:ember-users');
+    this.controller.model = model;
+  });
+
+  test('We sort users of Ember.js by featured, then by added', function (assert) {
+    const { sortedModel } = this.controller;
+
+    // Create an intermediate data structure for assertion
+    const output = sortedModel.map((user) => user.id);
+
+    assert.deepEqual(
+      output,
+      [
+        'ted',
+        'netflix',
+        'linkedin',
+        'velocity-labs',
+        'wnyc',
+        'clark-smart-insurance',
+        '201-created',
+        'articad',
+      ],
+      'We get the correct output.'
+    );
+  });
+});

--- a/tests/unit/controllers/mascots/index-test.js
+++ b/tests/unit/controllers/mascots/index-test.js
@@ -1,0 +1,13 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Controller | mascots/index', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    const controller = this.owner.lookup('controller:mascots/index');
+
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/controllers/releases/index-test.js
+++ b/tests/unit/controllers/releases/index-test.js
@@ -1,0 +1,32 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupTest } from 'ember-qunit';
+import projects from 'ember-website/mirage/data/projects';
+import { module, test } from 'qunit';
+
+module('Unit | Controller | releases/index', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    // Create Meetup data
+    this.server.db.loadData({ projects });
+
+    // Run model hook
+    const store = this.owner.lookup('service:store');
+    const model = await store.findAll('project');
+
+    // Run setupController hook
+    this.controller = this.owner.lookup('controller:releases/index');
+    this.controller.model = model;
+  });
+
+  test('We can find the Ember beta project', function (assert) {
+    const { emberBetaProject } = this.controller;
+
+    assert.strictEqual(
+      emberBetaProject?.id,
+      'ember/beta',
+      'We found the Ember beta project.'
+    );
+  });
+});

--- a/tests/unit/controllers/releases/lts-test.js
+++ b/tests/unit/controllers/releases/lts-test.js
@@ -1,0 +1,13 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Controller | releases/lts', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    const controller = this.owner.lookup('controller:releases/lts');
+
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/controllers/sponsors-test.js
+++ b/tests/unit/controllers/sponsors-test.js
@@ -1,0 +1,87 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupTest } from 'ember-qunit';
+import sponsors from 'ember-website/mirage/data/sponsors';
+import { module, test } from 'qunit';
+
+module('Unit | Controller | sponsors', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    // Create Meetup data
+    this.server.db.loadData({ sponsors });
+
+    // Run model hook
+    const store = this.owner.lookup('service:store');
+    const model = await store.findAll('sponsor');
+
+    // Run setupController hook
+    this.controller = this.owner.lookup('controller:sponsors');
+    this.controller.model = model;
+  });
+
+  test('We sort sponsors by end, then by start', function (assert) {
+    const { sortedModel } = this.controller;
+
+    // Create an intermediate data structure for assertion
+    const output = sortedModel.map((sponsor) => sponsor.id);
+
+    assert.deepEqual(
+      output,
+      [
+        '201-created',
+        'discourse',
+        'bookingsync',
+        'yapp',
+        'dockyard',
+        'bustle',
+        'yahoo',
+        'addepar',
+        'mhelabs',
+        'livingsocial',
+        'tilde',
+        'linkedin',
+        'cardstack',
+        'simplabs',
+      ],
+      'We get the correct output.'
+    );
+  });
+
+  test('We sort current sponsors by start', function (assert) {
+    const { currentSponsors } = this.controller;
+
+    // Create an intermediate data structure for assertion
+    const output = currentSponsors.map((sponsor) => sponsor.id);
+
+    assert.deepEqual(
+      output,
+      ['tilde', 'linkedin', 'cardstack', 'simplabs'],
+      'We get the correct output.'
+    );
+  });
+
+  test('We sort past sponsors by end, then by start', function (assert) {
+    const { pastSponsors } = this.controller;
+
+    // Create an intermediate data structure for assertion
+    const output = pastSponsors.map((sponsor) => sponsor.id);
+
+    assert.deepEqual(
+      output,
+      [
+        '201-created',
+        'discourse',
+        'bookingsync',
+        'yapp',
+        'dockyard',
+        'bustle',
+        'yahoo',
+        'addepar',
+        'mhelabs',
+        'livingsocial',
+      ],
+      'We get the correct output.'
+    );
+  });
+});

--- a/tests/unit/controllers/team-test.js
+++ b/tests/unit/controllers/team-test.js
@@ -1,0 +1,163 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupTest } from 'ember-qunit';
+import teamMembers from 'ember-website/mirage/data/team-members';
+import { module, test } from 'qunit';
+
+module('Unit | Controller | team', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    // Create Meetup data
+    this.server.db.loadData({ teamMembers });
+
+    // Run model hook
+    const store = this.owner.lookup('service:store');
+    const model = await store.findAll('team-member');
+
+    // Run setupController hook
+    this.controller = this.owner.lookup('controller:team');
+    this.controller.model = model;
+  });
+
+  test('We sort Steering team members by surname, then by given name', function (assert) {
+    const { steeringCommitteeMembers } = this.controller;
+
+    // Create an intermediate data structure for assertion
+    const output = steeringCommitteeMembers.map((teamMember) => teamMember.id);
+
+    assert.deepEqual(
+      output,
+      [
+        'tom-dale',
+        'edward-faulkner',
+        'katie-gengler',
+        'yehuda-katz',
+        'leah-silber',
+      ],
+      'We get the correct output.'
+    );
+  });
+
+  test('We sort Core team members by surname, then by given name', function (assert) {
+    const { coreTeamMembers } = this.controller;
+
+    // Create an intermediate data structure for assertion
+    const output = coreTeamMembers.map((teamMember) => teamMember.id);
+
+    assert.deepEqual(
+      output,
+      [
+        'matthew-beale',
+        'godfrey-chan',
+        'tom-dale',
+        'edward-faulkner',
+        'chris-garrett',
+        'dan-gebhardt',
+        'katie-gengler',
+        'chad-hietala',
+        'robert-jackson',
+        'yehuda-katz',
+        'ricardo-mendes',
+        'kris-selden',
+        'leah-silber',
+        'melanie-sumner',
+        'igor-terzic',
+      ],
+      'We get the correct output.'
+    );
+  });
+
+  test('We sort CLI team members by surname, then by given name', function (assert) {
+    const { coreCLITeamMembers } = this.controller;
+
+    // Create an intermediate data structure for assertion
+    const output = coreCLITeamMembers.map((teamMember) => teamMember.id);
+
+    assert.deepEqual(
+      output,
+      [
+        'krati-ahuja',
+        'katie-gengler',
+        'robert-jackson',
+        'alex-navasardyan',
+        'kelly-selden',
+      ],
+      'We get the correct output.'
+    );
+  });
+
+  test('We sort Data team members by surname, then by given name', function (assert) {
+    const { dataTeamMembers } = this.controller;
+
+    // Create an intermediate data structure for assertion
+    const output = dataTeamMembers.map((teamMember) => teamMember.id);
+
+    assert.deepEqual(
+      output,
+      [
+        'dan-gebhardt',
+        'david-hamilton',
+        'robert-jackson',
+        'igor-terzic',
+        'chris-thoburn',
+      ],
+      'We get the correct output.'
+    );
+  });
+
+  test('We sort Learning team members by surname, then by given name', function (assert) {
+    const { learningTeamMembers } = this.controller;
+
+    // Create an intermediate data structure for assertion
+    const output = learningTeamMembers.map((teamMember) => teamMember.id);
+
+    assert.deepEqual(
+      output,
+      [
+        'jared-galanis',
+        'jessica-jordan',
+        'amy-lam',
+        'kenneth-larsen',
+        'isaac-lee',
+        'chris-manson',
+        'ricardo-mendes',
+        'leah-silber',
+        'robert-wagner',
+        'jen-weber',
+      ],
+      'We get the correct output.'
+    );
+  });
+
+  test('We sort Emertius team members by surname, then by given name', function (assert) {
+    const { alumniTeamMembers } = this.controller;
+
+    // Create an intermediate data structure for assertion
+    const output = alumniTeamMembers.map((teamMember) => teamMember.id);
+
+    assert.deepEqual(
+      output,
+      [
+        'david-baker',
+        'tobias-bieniek',
+        'jacob-bixby',
+        'erik-bryn',
+        'trek-glowacki',
+        'nathan-hammond',
+        'todd-jordan',
+        'sivakumar-kailasam',
+        'terence-lee',
+        'alex-matchneer',
+        'brendan-mc-loughlin',
+        'clemens-muller',
+        'martin-munoz',
+        'stefan-penner',
+        'christoffer-persson',
+        'stanley-stuart',
+        'peter-wagenet',
+      ],
+      'We get the correct output.'
+    );
+  });
+});

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -17,12 +17,6 @@ module('Unit | Model | project', function (hooks) {
       assert.ok(model, 'We can create the record.');
 
       assert.strictEqual(
-        model.isEmberBeta,
-        false,
-        'We get the correct value for isEmberBeta.'
-      );
-
-      assert.strictEqual(
         model.lastReleaseChangelogUrl,
         'https://github.com/emberjs/ember.js/blob/v3.20.6/CHANGELOG.md',
         'We get the correct value for lastReleaseChangelogUrl.'
@@ -34,12 +28,6 @@ module('Unit | Model | project', function (hooks) {
       const model = this.store.createRecord('project', attributes);
 
       assert.ok(model, 'We can create the record.');
-
-      assert.strictEqual(
-        model.isEmberBeta,
-        false,
-        'We get the correct value for isEmberBeta.'
-      );
 
       assert.strictEqual(
         model.lastReleaseChangelogUrl,
@@ -55,12 +43,6 @@ module('Unit | Model | project', function (hooks) {
       assert.ok(model, 'We can create the record.');
 
       assert.strictEqual(
-        model.isEmberBeta,
-        true,
-        'We get the correct value for isEmberBeta.'
-      );
-
-      assert.strictEqual(
         model.lastReleaseChangelogUrl,
         'https://github.com/emberjs/ember.js/blob/v3.25.0-beta.1/CHANGELOG.md',
         'We get the correct value for lastReleaseChangelogUrl.'
@@ -72,12 +54,6 @@ module('Unit | Model | project', function (hooks) {
       const model = this.store.createRecord('project', attributes);
 
       assert.ok(model, 'We can create the record.');
-
-      assert.strictEqual(
-        model.isEmberBeta,
-        false,
-        'We get the correct value for isEmberBeta.'
-      );
 
       assert.strictEqual(
         model.lastReleaseChangelogUrl,
@@ -99,12 +75,6 @@ module('Unit | Model | project', function (hooks) {
       assert.ok(model, 'We can create the record.');
 
       assert.strictEqual(
-        model.isEmberBeta,
-        false,
-        'We get the correct value for isEmberBeta.'
-      );
-
-      assert.strictEqual(
         model.lastReleaseChangelogUrl,
         'https://github.com/emberjs/data/blob/v3.24.0/CHANGELOG.md',
         'We get the correct value for lastReleaseChangelogUrl.'
@@ -118,12 +88,6 @@ module('Unit | Model | project', function (hooks) {
       assert.ok(model, 'We can create the record.');
 
       assert.strictEqual(
-        model.isEmberBeta,
-        false,
-        'We get the correct value for isEmberBeta.'
-      );
-
-      assert.strictEqual(
         model.lastReleaseChangelogUrl,
         'https://github.com/emberjs/data/blob/v3.25.0-beta.0/CHANGELOG.md',
         'We get the correct value for lastReleaseChangelogUrl.'
@@ -135,12 +99,6 @@ module('Unit | Model | project', function (hooks) {
       const model = this.store.createRecord('project', attributes);
 
       assert.ok(model, 'We can create the record.');
-
-      assert.strictEqual(
-        model.isEmberBeta,
-        false,
-        'We get the correct value for isEmberBeta.'
-      );
 
       assert.strictEqual(
         model.lastReleaseChangelogUrl,


### PR DESCRIPTION
## Background

Over the next month, we'll upgrade `ember-source` from `v3.20` to `v3.24` and ensure that we follow recommended practices in Ember Octane.


## Description

In this pull request, I added unit tests for controllers. These tests, in particular, assert how we sort data that are returned from the `model` hook.

Having these tests will help us rewrite controllers in native class. I imagine that, if we were to create components to break down large route templates, we can reuse the test setups that I created in this pull request.


## How to Review

I recommend reviewing commits one by one. Each commit makes a small, meaningful change.