### PR TITLE
Added tests to better document the project (Part 8)

### DIFF
--- a/tests/unit/controllers/community/meetups/index-test.js
+++ b/tests/unit/controllers/community/meetups/index-test.js
@@ -8,7 +8,7 @@ module('Unit | Controller | community/meetups/index', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    // Create Meetup data
+    // Create data
     this.server.db.loadData({ meetups });
 
     // Run model hook

--- a/tests/unit/controllers/ember-users-test.js
+++ b/tests/unit/controllers/ember-users-test.js
@@ -8,7 +8,7 @@ module('Unit | Controller | ember-users', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    // Create Meetup data
+    // Create data
     this.server.db.loadData({ users });
 
     // Run model hook

--- a/tests/unit/controllers/releases/index-test.js
+++ b/tests/unit/controllers/releases/index-test.js
@@ -8,7 +8,7 @@ module('Unit | Controller | releases/index', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    // Create Meetup data
+    // Create data
     this.server.db.loadData({ projects });
 
     // Run model hook

--- a/tests/unit/controllers/sponsors-test.js
+++ b/tests/unit/controllers/sponsors-test.js
@@ -8,7 +8,7 @@ module('Unit | Controller | sponsors', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    // Create Meetup data
+    // Create data
     this.server.db.loadData({ sponsors });
 
     // Run model hook

--- a/tests/unit/controllers/team-test.js
+++ b/tests/unit/controllers/team-test.js
@@ -8,7 +8,7 @@ module('Unit | Controller | team', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    // Create Meetup data
+    // Create data
     this.server.db.loadData({ teamMembers });
 
     // Run model hook

--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | application', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:application');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/community/meetups/index-test.js
+++ b/tests/unit/routes/community/meetups/index-test.js
@@ -1,12 +1,27 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupTest } from 'ember-qunit';
+import meetups from 'ember-website/mirage/data/meetups';
 import { module, test } from 'qunit';
 
 module('Unit | Route | community/meetups/index', function (hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  test('it exists', function (assert) {
+  hooks.beforeEach(function () {
+    this.server.db.loadData({ meetups });
+  });
+
+  test('The model hook returns all Meetups', async function (assert) {
     const route = this.owner.lookup('route:community/meetups/index');
+    const model = await route.model();
 
-    assert.ok(route);
+    // Create an intermediate data structure for assertion
+    const output = model.map(({ id }) => id);
+
+    assert.deepEqual(
+      output,
+      meetups.map(({ id }) => id),
+      'We get the correct output.'
+    );
   });
 });

--- a/tests/unit/routes/community/meetups/index-test.js
+++ b/tests/unit/routes/community/meetups/index-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | community/meetups/index', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:community/meetups/index');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/ember-community-survey-2016-test.js
+++ b/tests/unit/routes/ember-community-survey-2016-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | ember-community-survey-2016', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:ember-community-survey-2016');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/ember-community-survey-2017-test.js
+++ b/tests/unit/routes/ember-community-survey-2017-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | ember-community-survey-2017', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:ember-community-survey-2017');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/ember-community-survey-2018-test.js
+++ b/tests/unit/routes/ember-community-survey-2018-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | ember-community-survey-2018', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:ember-community-survey-2018');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/ember-community-survey-2019-test.js
+++ b/tests/unit/routes/ember-community-survey-2019-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | ember-community-survey-2019', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:ember-community-survey-2019');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/ember-users-test.js
+++ b/tests/unit/routes/ember-users-test.js
@@ -1,12 +1,27 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupTest } from 'ember-qunit';
+import users from 'ember-website/mirage/data/users';
 import { module, test } from 'qunit';
 
 module('Unit | Route | ember-users', function (hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  test('it exists', function (assert) {
+  hooks.beforeEach(function () {
+    this.server.db.loadData({ users });
+  });
+
+  test('The model hook returns all users of Ember.js', async function (assert) {
     const route = this.owner.lookup('route:ember-users');
+    const model = await route.model();
 
-    assert.ok(route);
+    // Create an intermediate data structure for assertion
+    const output = model.map(({ id }) => id);
+
+    assert.deepEqual(
+      output,
+      users.map(({ id }) => id),
+      'We get the correct output.'
+    );
   });
 });

--- a/tests/unit/routes/ember-users-test.js
+++ b/tests/unit/routes/ember-users-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | ember-users', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:ember-users');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/learn-test.js
+++ b/tests/unit/routes/learn-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | learn', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:learn');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/learn-test.js
+++ b/tests/unit/routes/learn-test.js
@@ -1,12 +1,27 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupTest } from 'ember-qunit';
+import showcases from 'ember-website/mirage/data/showcases';
 import { module, test } from 'qunit';
 
 module('Unit | Route | learn', function (hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  test('it exists', function (assert) {
+  hooks.beforeEach(function () {
+    this.server.db.loadData({ showcases });
+  });
+
+  test('The model hook returns all showcase projects', async function (assert) {
     const route = this.owner.lookup('route:learn');
+    const model = await route.model();
 
-    assert.ok(route);
+    // Create an intermediate data structure for assertion
+    const output = model.map(({ id }) => id);
+
+    assert.deepEqual(
+      output,
+      showcases.map(({ id }) => id),
+      'We get the correct output.'
+    );
   });
 });

--- a/tests/unit/routes/mascots-test.js
+++ b/tests/unit/routes/mascots-test.js
@@ -1,12 +1,27 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupTest } from 'ember-qunit';
+import tomsters from 'ember-website/mirage/data/tomsters';
 import { module, test } from 'qunit';
 
 module('Unit | Route | mascots', function (hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  test('it exists', function (assert) {
+  hooks.beforeEach(function () {
+    this.server.db.loadData({ tomsters });
+  });
+
+  test('The model hook returns all mascots', async function (assert) {
     const route = this.owner.lookup('route:mascots');
+    const model = await route.model();
 
-    assert.ok(route);
+    // Create an intermediate data structure for assertion
+    const output = model.map(({ id }) => id);
+
+    assert.deepEqual(
+      output,
+      tomsters.map(({ id }) => id),
+      'We get the correct output.'
+    );
   });
 });

--- a/tests/unit/routes/mascots-test.js
+++ b/tests/unit/routes/mascots-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | mascots', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:mascots');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/releases-test.js
+++ b/tests/unit/routes/releases-test.js
@@ -1,12 +1,27 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupTest } from 'ember-qunit';
+import projects from 'ember-website/mirage/data/projects';
 import { module, test } from 'qunit';
 
 module('Unit | Route | releases', function (hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  test('it exists', function (assert) {
+  hooks.beforeEach(function () {
+    this.server.db.loadData({ projects });
+  });
+
+  test('The model hook returns all releases', async function (assert) {
     const route = this.owner.lookup('route:releases');
+    const model = await route.model();
 
-    assert.ok(route);
+    // Create an intermediate data structure for assertion
+    const output = model.map(({ id }) => id);
+
+    assert.deepEqual(
+      output,
+      projects.map(({ id }) => id),
+      'We get the correct output.'
+    );
   });
 });

--- a/tests/unit/routes/releases-test.js
+++ b/tests/unit/routes/releases-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | releases', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:releases');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/releases/beta-test.js
+++ b/tests/unit/routes/releases/beta-test.js
@@ -1,12 +1,30 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupTest } from 'ember-qunit';
+import projects from 'ember-website/mirage/data/projects';
 import { module, test } from 'qunit';
 
 module('Unit | Route | releases/beta', function (hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  test('it exists', function (assert) {
+  hooks.beforeEach(function () {
+    this.server.db.loadData({ projects });
+  });
+
+  test('The model hook returns the beta projects', async function (assert) {
     const route = this.owner.lookup('route:releases/beta');
+    const model = await route.model();
 
-    assert.ok(route);
+    assert.strictEqual(
+      model.ember?.id,
+      'ember/beta',
+      'We found the Ember beta project.'
+    );
+
+    assert.strictEqual(
+      model.emberData?.id,
+      'emberData/beta',
+      'We found the Ember Data beta project.'
+    );
   });
 });

--- a/tests/unit/routes/releases/beta-test.js
+++ b/tests/unit/routes/releases/beta-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | releases/beta', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:releases/beta');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/releases/canary-test.js
+++ b/tests/unit/routes/releases/canary-test.js
@@ -1,12 +1,36 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupTest } from 'ember-qunit';
+import projects from 'ember-website/mirage/data/projects';
 import { module, test } from 'qunit';
 
 module('Unit | Route | releases/canary', function (hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  test('it exists', function (assert) {
+  hooks.beforeEach(function () {
+    this.server.db.loadData({ projects });
+  });
+
+  test('The model hook returns the canary projects', async function (assert) {
     const route = this.owner.lookup('route:releases/canary');
+    const model = await route.model();
 
-    assert.ok(route);
+    assert.strictEqual(
+      model.ember?.id,
+      'ember/canary',
+      'We found the Ember canary project.'
+    );
+
+    assert.strictEqual(
+      model.emberData?.id,
+      'emberData/canary',
+      'We found the Ember Data canary project.'
+    );
+
+    assert.strictEqual(
+      model.canaryInfo?.version,
+      '3.25.0-canary+635799d4',
+      'We found the metadata for canary project.'
+    );
   });
 });

--- a/tests/unit/routes/releases/canary-test.js
+++ b/tests/unit/routes/releases/canary-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | releases/canary', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:releases/canary');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/releases/index-test.js
+++ b/tests/unit/routes/releases/index-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | releases/index', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:releases/index');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/releases/lts-test.js
+++ b/tests/unit/routes/releases/lts-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | releases/lts', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:releases/lts');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/releases/lts-test.js
+++ b/tests/unit/routes/releases/lts-test.js
@@ -1,12 +1,24 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupTest } from 'ember-qunit';
+import projects from 'ember-website/mirage/data/projects';
 import { module, test } from 'qunit';
 
 module('Unit | Route | releases/lts', function (hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  test('it exists', function (assert) {
+  hooks.beforeEach(function () {
+    this.server.db.loadData({ projects });
+  });
+
+  test('The model hook returns the Ember LTS project', async function (assert) {
     const route = this.owner.lookup('route:releases/lts');
+    const model = await route.model();
 
-    assert.ok(route);
+    assert.strictEqual(
+      model?.id,
+      'ember/lts',
+      'We found the Ember LTS project.'
+    );
   });
 });

--- a/tests/unit/routes/releases/release-test.js
+++ b/tests/unit/routes/releases/release-test.js
@@ -1,12 +1,30 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupTest } from 'ember-qunit';
+import projects from 'ember-website/mirage/data/projects';
 import { module, test } from 'qunit';
 
 module('Unit | Route | releases/release', function (hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  test('it exists', function (assert) {
+  hooks.beforeEach(function () {
+    this.server.db.loadData({ projects });
+  });
+
+  test('The model hook returns the stable projects', async function (assert) {
     const route = this.owner.lookup('route:releases/release');
+    const model = await route.model();
 
-    assert.ok(route);
+    assert.strictEqual(
+      model.ember?.id,
+      'ember/release',
+      'We found the Ember stable project.'
+    );
+
+    assert.strictEqual(
+      model.emberData?.id,
+      'emberData/release',
+      'We found the Ember Data stable project.'
+    );
   });
 });

--- a/tests/unit/routes/releases/release-test.js
+++ b/tests/unit/routes/releases/release-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | releases/release', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:releases/release');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/sponsors-test.js
+++ b/tests/unit/routes/sponsors-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | sponsors', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:sponsors');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/sponsors-test.js
+++ b/tests/unit/routes/sponsors-test.js
@@ -1,12 +1,27 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupTest } from 'ember-qunit';
+import sponsors from 'ember-website/mirage/data/sponsors';
 import { module, test } from 'qunit';
 
 module('Unit | Route | sponsors', function (hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  test('it exists', function (assert) {
+  hooks.beforeEach(function () {
+    this.server.db.loadData({ sponsors });
+  });
+
+  test('The model hook returns all sponsors', async function (assert) {
     const route = this.owner.lookup('route:sponsors');
+    const model = await route.model();
 
-    assert.ok(route);
+    // Create an intermediate data structure for assertion
+    const output = model.map(({ id }) => id);
+
+    assert.deepEqual(
+      output,
+      sponsors.map(({ id }) => id),
+      'We get the correct output.'
+    );
   });
 });

--- a/tests/unit/routes/statusboard-test.js
+++ b/tests/unit/routes/statusboard-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | statusboard', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:statusboard');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/team-redirect-test.js
+++ b/tests/unit/routes/team-redirect-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | team-redirect', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:team-redirect');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/team-test.js
+++ b/tests/unit/routes/team-test.js
@@ -1,12 +1,27 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupTest } from 'ember-qunit';
+import teamMembers from 'ember-website/mirage/data/team-members';
 import { module, test } from 'qunit';
 
 module('Unit | Route | team', function (hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  test('it exists', function (assert) {
+  hooks.beforeEach(function () {
+    this.server.db.loadData({ teamMembers });
+  });
+
+  test('The model hook returns all team members', async function (assert) {
     const route = this.owner.lookup('route:team');
+    const model = await route.model();
 
-    assert.ok(route);
+    // Create an intermediate data structure for assertion
+    const output = model.map(({ id }) => id);
+
+    assert.deepEqual(
+      output,
+      teamMembers.map(({ id }) => id),
+      'We get the correct output.'
+    );
   });
 });

--- a/tests/unit/routes/team-test.js
+++ b/tests/unit/routes/team-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | team', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:team');
+
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
## Background

Over the next month, we'll upgrade `ember-source` from `v3.20` to `v3.24` and ensure that we follow recommended practices in Ember Octane.


## Description

In this pull request, I added unit tests for routes. These tests, in particular, assert what we return from the `model` hook.