### PR TITLE
Added Browser Support to top navigation menu

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,9 +1,9 @@
 import Controller from '@ember/controller';
 import { infoLinks } from 'ember-styleguide/constants/es-footer';
-import styleguideLinks from 'ember-styleguide/constants/links';
+import headerLinks from 'ember-website/utils/header-links';
 import replaceLinks from 'ember-website/utils/replace-links';
 
 export default class ApplicationController extends Controller {
-  links = replaceLinks(styleguideLinks);
+  links = replaceLinks(headerLinks);
   infoLinks = replaceLinks(infoLinks);
 }

--- a/app/utils/header-links.js
+++ b/app/utils/header-links.js
@@ -1,0 +1,177 @@
+export default [
+  {
+    name: 'Docs',
+    type: 'dropdown',
+    items: [
+      {
+        href: 'https://guides.emberjs.com',
+        name: 'Ember.js Guides',
+        type: 'link',
+      },
+      {
+        href: 'https://api.emberjs.com',
+        name: 'API Reference',
+        type: 'link',
+      },
+      {
+        href: 'https://cli.emberjs.com',
+        name: 'CLI Guides',
+        type: 'link',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        href: 'https://emberjs.com/learn',
+        name: 'Learn Ember',
+        type: 'link',
+      },
+    ],
+  },
+  {
+    name: 'Releases',
+    type: 'dropdown',
+    items: [
+      {
+        href: 'https://emberjs.com/releases',
+        name: 'Overview',
+        type: 'link',
+      },
+      {
+        href: 'https://emberjs.com/releases/lts',
+        name: '→ LTS',
+        type: 'link',
+      },
+      {
+        href: 'https://emberjs.com/releases/release',
+        name: '→ Stable',
+        type: 'link',
+      },
+      {
+        href: 'https://emberjs.com/releases/beta',
+        name: '→ Beta',
+        type: 'link',
+      },
+      {
+        href: 'https://emberjs.com/releases/canary',
+        name: '→ Canary',
+        type: 'link',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        href: 'https://emberjs.com/editions',
+        name: 'Editions',
+        type: 'link',
+      },
+      {
+        href: 'https://emberjs.com/browser-support',
+        name: 'Browser Support',
+        type: 'link',
+      },
+      {
+        href: 'https://deprecations.emberjs.com',
+        name: 'Deprecations',
+        type: 'link',
+      },
+      {
+        href: 'https://github.com/emberjs/rfc-tracking/issues',
+        name: 'RFC Tracking',
+        type: 'link',
+      },
+    ],
+  },
+  {
+    href: 'https://blog.emberjs.com',
+    name: 'Blog',
+    type: 'link',
+  },
+  {
+    name: 'Community',
+    type: 'dropdown',
+    items: [
+      {
+        href: 'https://emberjs.com/community',
+        name: 'The Ember Community',
+        type: 'link',
+      },
+      {
+        href: 'https://emberjs.com/guidelines',
+        name: 'Guidelines',
+        type: 'link',
+      },
+      {
+        href: 'https://help-wanted.emberjs.com/',
+        name: 'Help Wanted',
+        type: 'link',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        href: 'https://emberjs.com/community/meetups',
+        name: 'Meetups',
+        type: 'link',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        href: 'http://emberconf.com/',
+        name: 'Ember Conf',
+        type: 'link',
+      },
+    ],
+  },
+  {
+    name: 'About',
+    type: 'dropdown',
+    items: [
+      {
+        href: 'https://emberjs.com/teams',
+        name: 'The Team',
+        type: 'link',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        href: 'https://emberjs.com/logos',
+        name: 'Branding',
+        type: 'link',
+      },
+      {
+        href: 'https://emberjs.com/mascots',
+        name: 'Mascots',
+        type: 'link',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        href: 'https://emberjs.com/ember-users',
+        name: 'Who Uses Ember',
+        type: 'link',
+      },
+      {
+        href: 'https://emberjs.com/sponsors',
+        name: 'Sponsors',
+        type: 'link',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        href: 'https://emberjs.com/about/legal',
+        name: 'Legal',
+        type: 'link',
+      },
+      {
+        href: 'https://emberjs.com/security',
+        name: 'Security',
+        type: 'link',
+      },
+    ],
+  },
+];

--- a/tests/unit/utils/header-links-test.js
+++ b/tests/unit/utils/header-links-test.js
@@ -1,0 +1,8 @@
+import headerLinks from 'ember-website/utils/header-links';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | header-links', function () {
+  test('We can import the object', function (assert) {
+    assert.strictEqual(headerLinks.length, 5, 'We show 5 parent items.');
+  });
+});


### PR DESCRIPTION
## Background

In #745, we created a route called `browser-support`. To help people find this page, we want to add a link to the page to the top navigation menu, between `Releases - Editions` and `Releases - Deprecations`.

<img width="160" alt="" role="presentation" src="https://user-images.githubusercontent.com/16869656/105902818-6df5a580-601f-11eb-9645-621570bb30d0.png">

The problem is, the data that define the menu links come from the addon [ember-styleguide](https://github.com/ember-learn/ember-styleguide/blob/v5.1.0/addon/constants/links.js). As a result, we need to make a pull request in that repo, then upgrade the addon in `ember-website`.

A complication would arise because we haven't yet upgraded the addon to the latest version. There were breaking changes between `v4` and `v5`.


## Description

In this pull request, I duplicated the data from `ember-styleguide`, then updated the data so that we will show `Browser Support` between `Editions` and `Deprecations`. The update mirrors that in https://github.com/ember-learn/ember-styleguide/pull/359/files.

I think this is a good temporary fix until we can invest time to upgrading `ember-styleguide` to `v5.x`.