### PR TITLE
Update ember-styleguide to v5

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -26,3 +26,22 @@
 .align-middle {
   vertical-align: middle;
 }
+
+h1 + *,
+.text-xl + * {
+  margin-top: var(--spacing-3);
+}
+
+* + .text-xl {
+  margin-top: var(--spacing-6);
+}
+
+* + .text-lg,
+* + h2 {
+  margin-top: var(--spacing-5);
+}
+
+* + .text-md,
+* + h3 {
+  margin-top: var(--spacing-3);
+}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -45,3 +45,7 @@ h1 + *,
 * + h3 {
   margin-top: var(--spacing-3);
 }
+
+.mt-4 {
+  margin-top: var(--spacing-4);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "ember-qunit": "^5.1.1",
         "ember-resolver": "^8.0.2",
         "ember-source": "~3.24.0",
-        "ember-styleguide": "^4.3.0",
+        "ember-styleguide": "^5.1.0",
         "ember-template-lint": "^2.18.0",
         "ember-tether": "^2.0.0",
         "ember-truth-helpers": "^3.0.0",
@@ -15604,9 +15604,9 @@
       }
     },
     "node_modules/ember-styleguide": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ember-styleguide/-/ember-styleguide-4.3.0.tgz",
-      "integrity": "sha512-khnD4hC8+9p+dHPnmeU/UQ42coA66zZ1bPvR9IIXxHsSKxAJ+yjOIoUQI7u7vXuH/Mz1xbIImrG6IyjsXnDDaw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ember-styleguide/-/ember-styleguide-5.1.0.tgz",
+      "integrity": "sha512-wn7AtP8znDIijVerJUg15tPFiv6zflQJ2nSqwgYYV6lDSgvAi1yhFXm88RC8N8dClJNo5dRe/mhmmTB3LOQ3mw==",
       "dev": true,
       "dependencies": {
         "@ember/render-modifiers": "^1.0.2",
@@ -45266,9 +45266,9 @@
       }
     },
     "ember-styleguide": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ember-styleguide/-/ember-styleguide-4.3.0.tgz",
-      "integrity": "sha512-khnD4hC8+9p+dHPnmeU/UQ42coA66zZ1bPvR9IIXxHsSKxAJ+yjOIoUQI7u7vXuH/Mz1xbIImrG6IyjsXnDDaw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ember-styleguide/-/ember-styleguide-5.1.0.tgz",
+      "integrity": "sha512-wn7AtP8znDIijVerJUg15tPFiv6zflQJ2nSqwgYYV6lDSgvAi1yhFXm88RC8N8dClJNo5dRe/mhmmTB3LOQ3mw==",
       "dev": true,
       "requires": {
         "@ember/render-modifiers": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ember-qunit": "^5.1.1",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.24.0",
-    "ember-styleguide": "^4.3.0",
+    "ember-styleguide": "^5.1.0",
     "ember-template-lint": "^2.18.0",
     "ember-tether": "^2.0.0",
     "ember-truth-helpers": "^3.0.0",


### PR DESCRIPTION
This PR updates the ember-styleguide to the latest version 🎉 

The latest breaking change for ember-styleguide was removing landing page specific styles (things that don't make sense in the blog or other sites). This PR just adds those styles back in to the website as app-specific styles 👍 