### PR TITLE
Update mascot-filters.hbs

### DIFF
--- a/app/components/mascots/mascot-filters.hbs
+++ b/app/components/mascots/mascot-filters.hbs
@@ -1,4 +1,4 @@
-<nav class="filter flex-horizontal-between">
+<nav class="filter flex-horizontal-between" aria-label="mascot filters">
   <span class="filter-group">
     {{#each this.filterFilters as |filter|}}
       <LinkTo


### PR DESCRIPTION
If merged, this would add an aria-label to the mascot filter navigation (which is not the only nav on the page, and should therefore have a unique label).