### PR TITLE
Added links to Open Collective and GitHub Sponsors to the Sponsors page

### DIFF
--- a/app/templates/sponsors.hbs
+++ b/app/templates/sponsors.hbs
@@ -5,7 +5,7 @@
   </h1>
 
   <p>
-    Since its beginnings in 2011, Ember has only gotten as far as we have due to the support&mdash;both financial and technical&mdash;of the following companies:
+    Since its beginnings in 2011, Ember has been able to grow to where we are now, thanks to the support&mdash;both financial and technical&mdash;of various companies and individuals:
   </p>
 
   <section class="my-5" aria-labelledby="ember-sponsors-and-friends-current-sponsors">
@@ -60,7 +60,15 @@
     </ul>
   </section>
 
-  <p class="text-center my-5">
-    A special thanks to <a href="https://dribbble.com/mg" rel="nofollow noopener noreferrer" target="_blank">Matt Grantham</a> for design of the original Ember website.
-  </p>
+  <section class="my-5" aria-labelledby="ember-sponsors-and-friends-individual-sponsors">
+    <h2 id="ember-sponsors-and-friends-individual-sponsors">Individual Sponsors</h2>
+
+    <p>
+      If you can help fund the development of Ember, we encourage you to visit our <a href="https://opencollective.com/emberjs">Open Collective</a> and <a href="https://github.com/sponsors/emberjs">GitHub Sponsors</a> channels. You can provide your donation in either channel. All financial contributions are moved to Open Collective and centrally, publicly managed there.
+    </p>
+
+    <p>
+      A special thanks goes to <a href="https://dribbble.com/mg" rel="nofollow noopener noreferrer" target="_blank">Matt Grantham</a> for designing the original Ember website.
+    </p>
+  </section>
 </section>


### PR DESCRIPTION
## Description

This pull request can close https://github.com/ember-learn/ember-website/issues/755. I opened a PR first so that we may use the deploy preview website to provide one another feedback better.


## References

A couple of links in case we want to embed buttons.

- https://docs.opencollective.com/help/collectives/widgets
- https://github.community/t/embed-sponsor-button-seems-to-be-broken/118493/2