### PR TITLE
Hide the "Upcoming releases" title on mobile devices

### DIFF
--- a/app/templates/releases/index.hbs
+++ b/app/templates/releases/index.hbs
@@ -25,7 +25,7 @@
   releases.
 </p>
 
-<h2>Upcoming releases</h2>
+<h2 class="hide-on-mobile">Upcoming releases</h2>
 
 <Releases::ReleaseTimeline
   @emberBetaProject={{this.emberBetaProject}}


### PR DESCRIPTION
This hides the title on mobile devices and makes it consistent with the Tomster statues.