### PR TITLE
Updated Releases page to announce 3.25 release

### DIFF
--- a/app/controllers/releases/lts.js
+++ b/app/controllers/releases/lts.js
@@ -3,6 +3,10 @@ import Controller from '@ember/controller';
 export default class ReleasesLtsController extends Controller {
   currentlySupportedLTS = [
     {
+      version: '3.24',
+      promotionDate: new Date('February 25, 2021'),
+    },
+    {
       version: '3.20',
       promotionDate: new Date('August 24, 2020'),
     },

--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -5,14 +5,14 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.24.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-lastRelease: 3.25.0-beta.1 # Manually update
-futureVersion: 3.25.0-beta.2 # Manually update
-finalVersion: 3.25.0 # Manually update
+initialVersion: 3.25.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+lastRelease: 3.26.0-beta.2 # Manually update
+futureVersion: 3.26.0-beta.3 # Manually update
+finalVersion: 3.26.0 # Manually update
 channel: beta
-cycleEstimatedFinishDate: 2021-02-08 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
-date: 2020-12-28 # Manually update, get date for `initialVersion`
-nextDate: 2021-02-08 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+cycleEstimatedFinishDate: 2021-03-22 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+date: 2020-02-08 # Manually update, get date for `initialVersion`
+nextDate: 2021-03-22 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -11,7 +11,7 @@ futureVersion: 3.26.0-beta.3 # Manually update
 finalVersion: 3.26.0 # Manually update
 channel: beta
 cycleEstimatedFinishDate: 2021-03-22 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
-date: 2020-02-08 # Manually update, get date for `initialVersion`
+date: 2021-02-08 # Manually update, get date for `initialVersion`
 nextDate: 2021-03-22 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js

--- a/data/project/ember/lts.md
+++ b/data/project/ember/lts.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.20.0
-initialReleaseDate: 2020-07-13
-lastRelease: 3.20.6
-futureVersion: 3.20.7
+initialVersion: 3.24.0
+initialReleaseDate: 2020-12-28
+lastRelease: 3.24.2
+futureVersion: 3.24.3
 channel: lts
-date: 2020-09-09
+date: 2021-02-25
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.24.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-initialReleaseDate: 2020-12-28 # Manually update
-lastRelease: 3.24.0 # Manually update
-futureVersion: 3.24.1 # Manually update
+initialVersion: 3.25.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+initialReleaseDate: 2021-02-08 # Manually update
+lastRelease: 3.25.1 # Manually update
+futureVersion: 3.25.2 # Manually update
 channel: release
-date: 2021-01-07 # Manually update, is today's date
+date: 2021-02-25 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -4,11 +4,11 @@ baseFileName: ember-data
 filter:
  - /ember-data\./
 repo: emberjs/data
-lastRelease: 3.25.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-futureVersion: 3.25.0-beta.1 # Manually update
-finalVersion: 3.25.0 # Manually update
+lastRelease: 3.26.0-beta.2 # Manually update, see https://libraries.io/npm/ember-data throughout
+futureVersion: 3.26.0-beta.3 # Manually update
+finalVersion: 3.26.0 # Manually update
 channel: beta
-date: 2021-01-05 # Manually update, get date for `lastRelease` 
+date: 2021-02-15 # Manually update, get date for `lastRelease` 
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ignoreFiles:

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -4,8 +4,8 @@ baseFileName: ember-data
 filter:
  - /ember-data\./
 repo: emberjs/data
-lastRelease: 3.26.0-beta.2 # Manually update, see https://libraries.io/npm/ember-data throughout
-futureVersion: 3.26.0-beta.3 # Manually update
+lastRelease: 3.26.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+futureVersion: 3.26.0-beta.1 # Manually update
 finalVersion: 3.26.0 # Manually update
 channel: beta
 date: 2021-02-15 # Manually update, get date for `lastRelease` 

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -8,7 +8,7 @@ lastRelease: 3.26.0-beta.0 # Manually update, see https://libraries.io/npm/ember
 futureVersion: 3.26.0-beta.1 # Manually update
 finalVersion: 3.26.0 # Manually update
 channel: beta
-date: 2021-02-15 # Manually update, get date for `lastRelease` 
+date: 2021-02-16 # Manually update, get date for `lastRelease` 
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ignoreFiles:

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -4,12 +4,12 @@ baseFileName: ember-data
 filter:
   - /ember-data\./
 repo: emberjs/data
-initialVersion: 3.24.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-initialReleaseDate: 2021-01-05 # Manually update, get date for `initialVersion`
-lastRelease: 3.24.0 # Manually update
-futureVersion: 3.24.1 # Manually update
+initialVersion: 3.25.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+initialReleaseDate: 2021-02-12 # Manually update, get date for `initialVersion`
+lastRelease: 3.25.0 # Manually update
+futureVersion: 3.25.1 # Manually update
 channel: release
-date: 2021-01-07 # Manually update, is today's date
+date: 2021-02-25 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ---


### PR DESCRIPTION
I noticed that I was installing 3.25 while the website is unaware of this version. So I've updated it, similar to the changes in #695.

Feel free to squash merge these changes. I've made them through the Github UI and have no idea how to squash those commits.