### PR TITLE
Update ember-community-survey-2021.hbs

### DIFF
--- a/app/templates/ember-community-survey-2021.hbs
+++ b/app/templates/ember-community-survey-2021.hbs
@@ -11,12 +11,12 @@
   <div class="mt-3">
     <a
       class="es-button"
-      href="#"
+      href="https://tilde.wufoo.com/forms/2021-emberjs-community-survey"
       rel="noopener noreferrer"
       target="_blank"
       disabled
     >
-      Coming Soon!
+      Take The Survey Now
     </a>
   </div>
 </EmberCommunitySurvey::Introduction>

--- a/app/templates/ember-community-survey-2021.hbs
+++ b/app/templates/ember-community-survey-2021.hbs
@@ -50,11 +50,11 @@
         >
 
         <h3>
-          Open until March 12th
+          Open until March 14th
         </h3>
 
         <p>
-          Submissions close on March 12th. To ensure the survey captures a fair measure of our community, please share this page on your social networks and with your local communities!
+          Submissions close on March 14th. To ensure the survey captures a fair measure of our community, please share this page on your social networks and with your local communities!
         </p>
       </div>
 

--- a/app/templates/ember-community-survey-2021.hbs
+++ b/app/templates/ember-community-survey-2021.hbs
@@ -14,7 +14,6 @@
       href="https://tilde.wufoo.com/forms/2021-emberjs-community-survey"
       rel="noopener noreferrer"
       target="_blank"
-      disabled
     >
       Take The Survey Now
     </a>

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -56,6 +56,7 @@ module.exports = function (defaults) {
         'ember-community-survey-2018',
         'ember-community-survey-2019',
         'ember-community-survey-2020',
+        'ember-community-survey-2021',
         'ember-users',
         'guidelines',
         'learn',

--- a/tests/acceptance/ember-community-survey-2021-test.js
+++ b/tests/acceptance/ember-community-survey-2021-test.js
@@ -1,0 +1,32 @@
+import { visit } from '@ember/test-helpers';
+import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import loadDefaultScenario from 'ember-website/mirage/scenarios/default';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
+import { module, test } from 'qunit';
+
+module('Acceptance | ember-community-survey-2021', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupPageTitleTest(hooks);
+
+  hooks.beforeEach(function () {
+    loadDefaultScenario(this.server);
+  });
+
+  test('Percy snapshot', async function (assert) {
+    await visit('/ember-community-survey-2021');
+    await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/ember-community-survey-2021');
+    await a11yAudit();
+
+    assert.hasPageTitle('Ember Community Survey 2021 - Ember.js');
+  });
+});


### PR DESCRIPTION
Adds the link for the 2021 community survey (to go live March 1, 2021)

Changes to this year (compared to last year): 
- updated for 2021 (prose, Ember versions)
- some instances of checkboxes were changed to radio buttons
- an a11y-related question was removed
- some instances where "how many" selections were overlapping were fixed
- some question answer options were changed, based on last year's results
- more single choice selections were set to be randomized (each user will see the options in a random order)
- additional "other" selections are allowed

Note: there will still need to be some decision made about the website banner. Do we want to change the link that is there, since that's where the survey link has gone in past years? 

Also it would be good (cc @mansona) if emberjs.com/survey could redirect to the survey link for the current year! 