### PR TITLE
Created survey route

### DIFF
--- a/.netlifyredirects
+++ b/.netlifyredirects
@@ -11,6 +11,7 @@
 /legal  /about/legal
 /meetup-assets  /community/meetups/assets
 /statusboard  https://github.com/emberjs/rfc-tracking/issues
+/survey  /ember-community-survey-2021
 /team  /teams
 /tomster/*  /mascots/:splat
 /zoey  /mascots

--- a/.netlifyredirects
+++ b/.netlifyredirects
@@ -1,19 +1,19 @@
-/internal   /api
+/about*  /
+/blog/*  https://blog.emberjs.com/:splat
+/branding  /logos
+/brand  /logos
+/builds/*  /releases/:splat
+/dashboard  /statusboard
+/deprecations/*  https://deprecations.emberjs.com/:splat
+/documentation/*  https://guides.emberjs.com/release/:splat
+/guides/*  https://guides.emberjs.com/release/:splat
+/internal  /api
+/legal  /about/legal
+/meetup-assets  /community/meetups/assets
+/statusboard  https://github.com/emberjs/rfc-tracking/issues
+/team  /teams
 /tomster/*  /mascots/:splat
-/dasboard   /statusboard
-/statusboard https://github.com/emberjs/rfc-tracking/issues
-/guides/*   https://guides.emberjs.com/release/:splat
-/documentation/*   https://guides.emberjs.com/release/:splat
-/builds/*   /releases/:splat
-/about*     /
-/legal      /about/legal
-/zoey       /mascots
-/brand      /logos/
-/branding   /logos
-/team       /teams
-/meetup-assets  /community/meetups/assets/
-/blog/*         https://blog.emberjs.com/:splat
-/deprecations/* https://deprecations.emberjs.com/:splat
+/zoey  /mascots
 
 ### API Redirects
 

--- a/app/router.js
+++ b/app/router.js
@@ -63,6 +63,8 @@ Router.map(function () {
 
   this.route('sponsors');
 
+  this.route('survey');
+
   this.route('team-redirect', { path: 'team' });
   this.route('teams');
 });

--- a/app/routes/survey.js
+++ b/app/routes/survey.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class SurveyRoute extends Route {
+  redirect() {
+    this.transitionTo('ember-community-survey-2021');
+  }
+}

--- a/app/templates/survey.hbs
+++ b/app/templates/survey.hbs
@@ -1,0 +1,3 @@
+{{page-title "Ember Community Survey"}}
+
+{{outlet}}

--- a/app/utils/header-links.js
+++ b/app/utils/header-links.js
@@ -123,8 +123,8 @@ export default [
         type: 'link',
       },
       {
-        href: 'http://emberconf.com/',
-        name: 'Ember Conf',
+        href: 'https://emberconf.com/',
+        name: 'EmberConf',
         type: 'link',
       },
     ],

--- a/app/utils/header-links.js
+++ b/app/utils/header-links.js
@@ -118,6 +118,11 @@ export default [
         type: 'divider',
       },
       {
+        href: 'https://emberjs.com/survey',
+        name: 'Ember Community Survey',
+        type: 'link',
+      },
+      {
         href: 'http://emberconf.com/',
         name: 'Ember Conf',
         type: 'link',

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -122,7 +122,7 @@ module('Acceptance | index', function (hooks) {
         { href: 'https://help-wanted.emberjs.com/', label: 'Help Wanted' },
         { href: '/community/meetups', label: 'Meetups' },
         { href: '/survey', label: 'Ember Community Survey' },
-        { href: 'http://emberconf.com/', label: 'Ember Conf' },
+        { href: 'https://emberconf.com/', label: 'EmberConf' },
       ],
       parentNavItems[3]
     );

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -121,6 +121,7 @@ module('Acceptance | index', function (hooks) {
         { href: '/guidelines', label: 'Guidelines' },
         { href: 'https://help-wanted.emberjs.com/', label: 'Help Wanted' },
         { href: '/community/meetups', label: 'Meetups' },
+        { href: '/survey', label: 'Ember Community Survey' },
         { href: 'http://emberconf.com/', label: 'Ember Conf' },
       ],
       parentNavItems[3]

--- a/tests/acceptance/survey-test.js
+++ b/tests/acceptance/survey-test.js
@@ -1,0 +1,28 @@
+import { currentURL, visit } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import loadDefaultScenario from 'ember-website/mirage/scenarios/default';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
+import { module, test } from 'qunit';
+
+module('Acceptance | survey', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupPageTitleTest(hooks);
+
+  hooks.beforeEach(function () {
+    loadDefaultScenario(this.server);
+  });
+
+  test('When a user visits /survey, we redirect them to /ember-community-survey-2021', async function (assert) {
+    await visit('/survey');
+
+    assert.strictEqual(
+      currentURL(),
+      '/ember-community-survey-2021',
+      'The URL is correct.'
+    );
+
+    assert.hasPageTitle('Ember Community Survey 2021 - Ember.js');
+  });
+});

--- a/tests/unit/routes/survey-test.js
+++ b/tests/unit/routes/survey-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | survey', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:survey');
+
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
## Description

I think this PR can address 2 suggestions from @MelSumner:

- Have `survey` route redirect to `ember-community-survey-2021` (https://github.com/ember-learn/ember-website/pull/780)
- Add `survey` route as a landing page for survey results pages (https://github.com/ember-learn/ember-website/issues/765)

When you visit `/survey` URL, you will be redirected to `/ember-community-survey-2021`.


## How to Review

I recommend reviewing commits one by one. Each commit makes a small, meaningful change.