### PR TITLE
Remove blog route

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -11,8 +11,6 @@ Router.map(function () {
     this.route('legal');
   });
 
-  this.route('blog', function () {});
-
   this.route('browser-support');
 
   this.route('community', function () {


### PR DESCRIPTION
It seems this route is not needed anymore because of the Netlify redirect? Feel free to close if I'm mistaken!