### PR TITLE
Add not-found route

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -52,6 +52,8 @@ Router.map(function () {
     this.route('payment-sent');
   });
 
+  this.route('not-found', { path: '/*path' });
+
   this.route('releases', function () {
     this.route('beta');
     this.route('canary');

--- a/app/routes/not-found.js
+++ b/app/routes/not-found.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class NotFoundRoute extends Route {
+  @service fastboot;
+
+  beforeModel() {
+    if (!this.fastboot.isFastBoot) {
+      return;
+    }
+
+    this.fastboot.response.statusCode = 404;
+  }
+}

--- a/app/templates/not-found.hbs
+++ b/app/templates/not-found.hbs
@@ -1,0 +1,6 @@
+{{page-title "Page Not Found"}}
+
+<div class="container">
+  <h1>Page Not Found</h1>
+  <p>We couldn't find what you were looking for.</p>
+</div>

--- a/tests/acceptance/not-found-test.js
+++ b/tests/acceptance/not-found-test.js
@@ -1,0 +1,32 @@
+import { visit } from '@ember/test-helpers';
+import percySnapshot from '@percy/ember';
+import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setupApplicationTest } from 'ember-qunit';
+import loadDefaultScenario from 'ember-website/mirage/scenarios/default';
+import { setupPageTitleTest } from 'ember-website/tests/helpers/page-title';
+import { module, test } from 'qunit';
+
+module('Acceptance | not found', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupPageTitleTest(hooks);
+
+  hooks.beforeEach(function () {
+    loadDefaultScenario(this.server);
+  });
+
+  test('Percy snapshot', async function (assert) {
+    await visit('/foo-bar-baz');
+    await percySnapshot(assert);
+
+    assert.ok(true);
+  });
+
+  test('Accessibility audit', async function (assert) {
+    await visit('/foo-bar-baz');
+    await a11yAudit();
+
+    assert.hasPageTitle('Page Not Found - Ember.js');
+  });
+});

--- a/tests/unit/routes/not-found-test.js
+++ b/tests/unit/routes/not-found-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Unit | Route | not-found', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const route = this.owner.lookup('route:not-found');
+
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
Far from perfect, but at the moment non-existent URLs return a blank screen.

Let me know if I should update anything related to UI, UX, A11Y, copy and so on.

<img width="1440" alt="Screenshot 2021-03-05 at 19 39 39 (2)" src="https://user-images.githubusercontent.com/7403183/110159923-9d9c8800-7deb-11eb-814e-88c53201c4ca.png">