### PR TITLE
Improve LTS table alignment

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -5,6 +5,7 @@
 @import "components/ember-survey.css";
 @import "components/faqs.css";
 @import "components/homepage-image-grid.css";
+@import "components/lts-table.css";
 @import "components/release-timeline.css";
 @import "components/survey-section.css";
 @import "components/surveys.css";

--- a/app/styles/components/lts-table.css
+++ b/app/styles/components/lts-table.css
@@ -1,0 +1,17 @@
+.lts-table {
+  border-spacing: 0;
+}
+
+.lts-table th {
+  text-align: left;
+}
+
+.lts-table td,
+.lts-table th {
+  padding: 0 var(--spacing-2) var(--spacing-1) 0;
+}
+
+.lts-table td:last-child,
+.lts-table th:last-child {
+  padding-right: 0;
+}

--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -50,7 +50,7 @@
 </p>
 
 <div class="mb-2">
-  <table>
+  <table class="lts-table">
     <thead>
       <tr>
         <th>LTS version</th>


### PR DESCRIPTION
I felt like the readability/alignment of the LTS table could slightly be improved. Hope this is okay.

Before:
<img width="682" alt="Before" src="https://user-images.githubusercontent.com/7403183/110215169-a99a4f80-7ea8-11eb-8693-efc8b51ce78f.png">

After:
<img width="681" alt="After" src="https://user-images.githubusercontent.com/7403183/110215179-b454e480-7ea8-11eb-9db9-442bf36a5452.png">