### PR TITLE
Hardcode full path to social image to match ember-blog

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,11 +6,11 @@
     <meta name="description" content="Ember.js helps developers be more productive out of the box. Designed with developer ergonomics in mind, its friendly APIs help you get your job done—fast.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta property="og:description" content="Ember.js helps developers be more productive out of the box. Designed with developer ergonomics in mind, its friendly APIs help you get your job done—fast." />
-    <meta property="og:image" content="/images/tomster-sm.png" />
+    <meta property="og:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@emberjs" />
     <meta name="google-site-verification" content="N9yOP2jCLcZBMHUet-JRqU2jnLVPeLDaePpkCqXGQXM" />
-    <meta name="twitter:image" content="/images/tomster-twitter-card.png" />
+    <meta name="twitter:image" content="https://blog.emberjs.com/images/logos/e-icon.png" />
 
     {{content-for "head"}}
 


### PR DESCRIPTION
Relates to: https://github.com/ember-learn/ember-website/pull/803 and https://github.com/ember-learn/ember-blog/pull/873

//

I'm not sure if this is the best approach (was originally trying to add the host so that the relative URL wouldn't be `/images/...`), but will sync us up with the blog and look better on Twitter for now. Let me know what you think.

May make sense to have a separate repo for shared assets?

WAS:
![image](https://user-images.githubusercontent.com/1372946/110992410-bdbbd200-832a-11eb-9750-f5a515a79923.png)

IS:
![image](https://user-images.githubusercontent.com/1372946/110993044-a7624600-832b-11eb-9673-794dd09f5f73.png)
