### PR TITLE
add ability to link to a particular mascot

### DIFF
--- a/app/components/mascots/mascot-list.hbs
+++ b/app/components/mascots/mascot-list.hbs
@@ -1,6 +1,6 @@
 <ul class="unstyled grid {{if (eq @display "small") "sm:grid-2 lg:grid-3" "sm:grid-1 lg:grid-2"}}">
   {{#each @mascots as |mascot|}}
-    <li id={{mascot.id}} data-test-mascot>
+    <li data-test-mascot>
       <Mascots::MascotList::Item
         @mascot={{mascot}}
       />

--- a/app/components/mascots/mascot-list/item.hbs
+++ b/app/components/mascots/mascot-list/item.hbs
@@ -1,4 +1,4 @@
-<figure>
+<figure class="mascot-item" id={{@mascot.id}}>
   <div class="well well-1/1">
     <ResponsiveImage
       @src="/images/tomsters/{{@mascot.image}}"

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -13,6 +13,7 @@
 @import "components/team-list.css";
 @import "components/terminal-code.css";
 @import "components/callout-banner.css";
+@import "components/mascots.css";
 @import "legacy/form.css";
 
 @media only percy {

--- a/app/styles/components/mascots.css
+++ b/app/styles/components/mascots.css
@@ -1,0 +1,3 @@
+.mascot-item:target .well {
+  border: 2px solid var(--color-brand-40);
+}


### PR DESCRIPTION
I found myself wanting to link to the Empress mascot recently so I added the ability to link to a particular mascot using an ID. 

Once this PR is merged you will be able to go to https://emberjs.com/mascots/#empress and it should scroll to the right part of the page and highlight the "target" mascot like this: 

<img width="1174" alt="Screenshot 2021-03-17 at 15 16 19" src="https://user-images.githubusercontent.com/594890/111491421-c1d55e80-8733-11eb-9899-521c47f4008a.png">

Let me know if you have any questions :) 

Edit: here is a link with the preview app to allow you to test if it's working https://deploy-preview-805--ember-website.netlify.app/mascots/#empress

Second Edit: this functionality was added in https://github.com/ember-learn/ember-website/pull/1009 and this PR now just adds the highlight to the linked Mascot