### PR TITLE
implement trailing-history location type

### DIFF
--- a/app/locations/trailing-history.js
+++ b/app/locations/trailing-history.js
@@ -1,0 +1,13 @@
+import HistoryLocation from '@ember/routing/history-location';
+
+export default class TrailingHistoryLocation extends HistoryLocation {
+  formatURL() {
+    let url = super.formatURL(...arguments);
+
+    if (url.includes('#')) {
+      return url.replace(/([^/])#(.*)/, '$1/#$2');
+    } else {
+      return url.replace(/\/?$/, '/');
+    }
+  }
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,7 +5,8 @@ module.exports = function (environment) {
     modulePrefix: 'ember-website',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'trailing-history',
+    historySupportMiddleware: true,
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build


### PR DESCRIPTION
This implements a trick that we use in all Empress projects to make sure that the url in the browser always matches what you would expect when you navigate to page on the website. It's a little bit hard to explain, and the ramifications are hard to quantify (and vast) but I will be able to explain with a simple statement and an example: 

After merging this PR, when you are navigating around the website you will **always** see a trailing `/` at the end of the URL. 

For example: Right now if you visit a sub-page of the website such as the logos page you will always see a trailing slash regardless if you put it in the url bar. Another way of expressing it is that if you visit https://emberjs.com/logos or https://emberjs.com/logos/ the browser will always add the trailing slash. 

In the current production website this is **not** true if you arrive at the logos page from an internal Ember navigation. e.g. First load https://emberjs.com and then click `About > Branding` in the Navbar and you will see that the browser has https://emberjs.com/logos **with no trailing slash** in the url bar. If you then refresh the browser will add the trailing slash again. 

This PR fixes that silliness 😄 