### PR TITLE
Announced Ember v3.26 release

### DIFF
--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -5,14 +5,14 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.25.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-lastRelease: 3.26.0-beta.2 # Manually update
-futureVersion: 3.26.0-beta.3 # Manually update
-finalVersion: 3.26.0 # Manually update
+initialVersion: 3.26.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+lastRelease: 3.27.0-beta.3 # Manually update
+futureVersion: 3.27.0-beta.4 # Manually update
+finalVersion: 3.27.0 # Manually update
 channel: beta
-cycleEstimatedFinishDate: 2021-03-22 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
-date: 2021-02-08 # Manually update, get date for `initialVersion`
-nextDate: 2021-03-22 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+cycleEstimatedFinishDate: 2021-05-03 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+date: 2021-03-22 # Manually update, get date for `initialVersion`
+nextDate: 2021-05-03 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/lts.md
+++ b/data/project/ember/lts.md
@@ -7,8 +7,8 @@ filter:
 repo: emberjs/ember.js
 initialVersion: 3.24.0
 initialReleaseDate: 2020-12-28
-lastRelease: 3.24.2
-futureVersion: 3.24.3
+lastRelease: 3.24.3
+futureVersion: 3.24.4
 channel: lts
 date: 2021-02-25
 changelogPath: CHANGELOG.md

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.25.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-initialReleaseDate: 2021-02-08 # Manually update
-lastRelease: 3.25.1 # Manually update
-futureVersion: 3.25.2 # Manually update
+initialVersion: 3.26.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+initialReleaseDate: 2021-03-22 # Manually update
+lastRelease: 3.26.1 # Manually update
+futureVersion: 3.26.2 # Manually update
 channel: release
-date: 2021-02-25 # Manually update, is today's date
+date: 2021-04-12 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -4,11 +4,11 @@ baseFileName: ember-data
 filter:
  - /ember-data\./
 repo: emberjs/data
-lastRelease: 3.26.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-futureVersion: 3.26.0-beta.1 # Manually update
-finalVersion: 3.26.0 # Manually update
+lastRelease: 3.27.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+futureVersion: 3.27.0-beta.1 # Manually update
+finalVersion: 3.27.0 # Manually update
 channel: beta
-date: 2021-02-16 # Manually update, get date for `lastRelease` 
+date: 2021-03-27 # Manually update, get date for `lastRelease` 
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ignoreFiles:

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -4,12 +4,12 @@ baseFileName: ember-data
 filter:
   - /ember-data\./
 repo: emberjs/data
-initialVersion: 3.25.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-initialReleaseDate: 2021-02-12 # Manually update, get date for `initialVersion`
-lastRelease: 3.25.0 # Manually update
-futureVersion: 3.25.1 # Manually update
+initialVersion: 3.26.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+initialReleaseDate: 2021-03-27 # Manually update, get date for `initialVersion`
+lastRelease: 3.26.0 # Manually update
+futureVersion: 3.26.1 # Manually update
 channel: release
-date: 2021-02-25 # Manually update, is today's date
+date: 2021-04-12 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ---


### PR DESCRIPTION
## Notes

I used https://libraries.io/npm/ember-source/versions and https://libraries.io/npm/ember-data/versions.