### PR TITLE
Updated SplineChart class

### DIFF
--- a/app/controllers/ember-community-survey-2017.js
+++ b/app/controllers/ember-community-survey-2017.js
@@ -7,96 +7,137 @@ const lightGrayColor = '#cccccc';
 
 const chartHowlong = new SplineChart({
   chart: {
-    title: 'Which version(s) of Ember are used in your apps?',
-    subtitle: 'Releases Prior to Survey',
-    tooltip: function () {
-      let s = `<b>${+this.x} Release${
-        Number(this.x) !== 1 ? 's' : ''
-      } Prior to Survey</b>`;
-
-      this.points.forEach((point) => {
-        s += `<br/><span style="color: ${point.color}">●</span>${point.series.name}: ${point.point.label} Release (${point.y}%)`;
-      });
-
-      return s;
-    },
-
     categories: [
-      '13',
-      '12',
-      '11',
-      '10',
-      '9',
-      '8',
-      '7',
-      '6',
-      '5',
-      '4',
-      '3',
-      '2',
-      '1',
-      '0',
+      '1.0',
+      '1.1',
+      '1.2',
+      '1.3',
+      '1.4',
+      '1.5',
+      '1.6',
+      '1.7',
+      '1.8',
+      '1.9',
+      '1.10',
+      '1.11',
+      '1.12',
+      '1.13',
+      '2.0',
+      '2.1',
+      '2.2',
+      '2.3',
+      '2.4',
+      '2.5',
+      '2.6',
+      '2.7',
+      '2.8',
+      '2.9',
+      '2.10',
+      '2.11',
+      '2.12',
     ],
+    title: 'Which versions of Ember are used in your apps?',
   },
+
   rawData: [
     {
+      color: lightGrayColor,
       label: '2015',
       values: [
-        null,
-        null,
-        null,
-        { y: 3, label: '1.0' },
-        { y: 1, label: '1.1' },
-        { y: 0.7, label: '1.2' },
-        { y: 2, label: '1.3' },
-        { y: 2.6, label: '1.4' },
-        { y: 3.9, label: '1.5' },
-        { y: 6.8, label: '1.6' },
-        { y: 15, label: '1.7' },
-        { y: 31.7, label: '1.8' },
-        { y: 39.5, label: '1.9' },
-        { y: 35, label: '1.10' },
+        3, // '1.0'
+        1, // '1.1'
+        0.7, // '1.2'
+        2, // '1.3'
+        2.6, // '1.4'
+        3.9, // '1.5'
+        6.8, // '1.6'
+        15, // '1.7'
+        31.7, //'1.8'
+        39.5, // '1.9'
+        35, // '1.10'
+        null, // '1.11'
+        null, // '1.12'
+        null, // '1.13'
+        null, // '2.0'
+        null, // '2.1'
+        null, // '2.2'
+        null, // '2.3'
+        null, // '2.4'
+        null, // '2.5'
+        null, // '2.6'
+        null, // '2.7'
+        null, // '2.8'
+        null, // '2.9'
+        null, // '2.10'
+        null, // '2.11'
+        null, // '2.12'
       ],
-      color: lightGrayColor,
     },
     {
+      color: darkGrayColor,
       label: '2016',
       values: [
-        { y: 1.8, label: '1.6' },
-        { y: 2.7, label: '1.7' },
-        { y: 3.5, label: '1.8' },
-        { y: 2.6, label: '1.9' },
-        { y: 3.9, label: '1.10' },
-        { y: 6, label: '1.11' },
-        { y: 5.8, label: '1.12' },
-        { y: 36, label: '1.13' },
-        { y: 8.2, label: '2.0' },
-        { y: 6.3, label: '2.1' },
-        { y: 11.5, label: '2.2' },
-        { y: 27, label: '2.3' },
-        { y: 47, label: '2.4' },
+        null, // '1.0'
+        null, // '1.1'
+        null, // '1.2'
+        null, // '1.3'
+        null, // '1.4'
+        null, // '1.5'
+        1.8, // '1.6'
+        2.7, // '1.7'
+        3.5, //'1.8'
+        2.6, // '1.9'
+        3.9, // '1.10'
+        6, // '1.11'
+        5.8, // '1.12'
+        36, // '1.13'
+        8.2, // '2.0'
+        6.3, // '2.1'
+        11.5, // '2.2'
+        27, // '2.3'
+        47, // '2.4'
+        null, // '2.5'
+        null, // '2.6'
+        null, // '2.7'
+        null, // '2.8'
+        null, // '2.9'
+        null, // '2.10'
+        null, // '2.11'
+        null, // '2.12'
       ],
-      color: darkGrayColor,
     },
     {
+      color: emberOrange,
       label: '2017',
       values: [
-        { y: 14.5, label: '1.13' },
-        { y: 3, label: '2.0' },
-        { y: 2.1, label: '2.1' },
-        { y: 2, label: '2.2' },
-        { y: 4.5, label: '2.3' },
-        { y: 11.3, label: '2.4' },
-        { y: 4.4, label: '2.5' },
-        { y: 4.5, label: '2.6' },
-        { y: 5.8, label: '2.7' },
-        { y: 21.2, label: '2.8' },
-        { y: 10, label: '2.9' },
-        { y: 22, label: '2.10' },
-        { y: 41, label: '2.11' },
-        { y: 19.3, label: 'stable (2.12)' },
+        null, // '1.0'
+        null, // '1.1'
+        null, // '1.2'
+        null, // '1.3'
+        null, // '1.4'
+        null, // '1.5'
+        null, // '1.6'
+        null, // '1.7'
+        null, //'1.8'
+        null, // '1.9'
+        null, // '1.10'
+        null, // '1.11'
+        null, // '1.12'
+        14.5, // '1.13'
+        3, // '2.0'
+        2.1, // '2.1'
+        2, // '2.2'
+        4.5, // '2.3'
+        11.3, // '2.4'
+        4.4, // '2.5'
+        4.5, // '2.6'
+        5.8, // '2.7'
+        21.2, // '2.8'
+        10, // '2.9'
+        22, // '2.10'
+        41, // '2.11'
+        19.3, // '2.12'
       ],
-      color: emberOrange,
     },
   ],
 }).highchartsOptions;
@@ -542,119 +583,71 @@ const demographics = new VerticalBarChart({
   ],
 }).highchartsOptions;
 
-const versionData = [
-  {
-    label: '2016',
-    color: darkGrayColor,
-    values: [
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      { value: 27, label: '1.13' },
-      { value: 6, label: '2.0' },
-      { value: 4, label: '2.1' },
-      { value: 8, label: '2.2' },
-      { value: 21, label: '2.3' },
-      { value: 42, label: '2.4' },
-      null,
-    ],
-  },
-  {
-    label: '2017',
-    color: emberOrange,
-    values: [
-      { value: 9, label: '1.13' },
-      { value: 2.15, label: '2.0' },
-      { value: 2.1, label: '2.1' },
-      { value: 1.5, label: '2.2' },
-      { value: 2.8, label: '2.3' },
-      { value: 7, label: '2.4' },
-      { value: 3, label: '2.5' },
-      { value: 4, label: '2.6' },
-      { value: 4, label: '2.7' },
-      { value: 13.8, label: '2.8' },
-      { value: 7, label: '2.9' },
-      { value: 21.6, label: '2.10' },
-      { value: 34.9, label: '2.11' },
-      { value: 17, label: 'stable (2.12)' },
-    ],
-  },
-];
-
 const priorVersionsData = new SplineChart({
   chart: {
-    title: 'Which versions of Ember Data are used in your apps?',
-    subtitle: 'Releases Prior to Survey',
-    tooltip: function () {
-      var releasesPrior = +this.x;
-      var s =
-        '<b>' +
-        +this.x +
-        ' Release' +
-        (releasesPrior !== 1 ? 's' : '') +
-        ' Prior to Survey</b>';
-      for (var i = 0; i < this.points.length; ++i) {
-        var point = this.points[i],
-          seriesName = point.series.name;
-        s +=
-          '<br/><span style="color:' +
-          point.color +
-          '">●</span>' +
-          seriesName +
-          ': ';
-        var labels;
-        for (var j = 0; j < versionData.length; ++j) {
-          if (versionData[j].label === seriesName) {
-            labels = versionData[j].values;
-          }
-        }
-        var label = labels[labels.length - 1 - releasesPrior].label;
-        s += label + ' Release (' + point.y + '%)';
-      }
-      return s;
-    },
     categories: [
-      '13',
-      '12',
-      '11',
-      '10',
-      '9',
-      '8',
-      '7',
-      '6',
-      '5',
-      '4',
-      '3',
-      '2',
-      '1',
-      '0',
+      '1.13',
+      '2.0',
+      '2.1',
+      '2.2',
+      '2.3',
+      '2.4',
+      '2.5',
+      '2.6',
+      '2.7',
+      '2.8',
+      '2.9',
+      '2.10',
+      '2.11',
+      '2.12',
     ],
+    title: 'Which versions of Ember Data are used in your apps?',
   },
-  rawData: makeVersionChartData(versionData),
+
+  rawData: [
+    {
+      color: darkGrayColor,
+      label: '2016',
+      values: [
+        27, // '1.13'
+        6, // '2.0'
+        4, // '2.1'
+        8, // '2.2'
+        21, // '2.3'
+        42, // '2.4'
+        null, // '2.5'
+        null, // '2.6'
+        null, // '2.7'
+        null, // '2.8'
+        null, // '2.9'
+        null, // '2.10'
+        null, // '2.11'
+        null, // '2.12'
+      ],
+    },
+    {
+      color: emberOrange,
+      label: '2017',
+      values: [
+        9, // '1.13'
+        2.15, // '2.0'
+        2.1, // '2.1'
+        1.5, // '2.2'
+        2.8, // '2.3'
+        7, // '2.4'
+        3, // '2.5'
+        4, // '2.6'
+        4, // '2.7'
+        13.8, // '2.8'
+        7, // '2.9'
+        21.6, // '2.10'
+        34.9, // '2.11'
+        17, // '2.12'
+      ],
+    },
+  ],
 }).highchartsOptions;
 
-function makeVersionChartData(versionData) {
-  var seriesData = [];
-
-  for (var i = 0; i < versionData.length; ++i) {
-    var _series = {
-      label: versionData[i].label,
-      values: versionData[i].values.map(function (d) {
-        return d && d.value;
-      }),
-    };
-    if (versionData[i].color) {
-      _series.color = versionData[i].color;
-    }
-    seriesData.push(_series);
-  }
-
-  return seriesData;
-}
 export default class EmberCommunitySurvey2017Controller extends Controller {
   chartHowlong = chartHowlong;
   chartSnapshotEmberDevelopers = chartSnapshotEmberDevelopers;

--- a/app/controllers/ember-community-survey-2017.js
+++ b/app/controllers/ember-community-survey-2017.js
@@ -175,74 +175,6 @@ const chartSnapshotEmberDevelopers = new VerticalBarChart({
   ],
 }).highchartsOptions;
 
-const chartBreakdownByVersion = new VerticalBarChart({
-  chart: {
-    categories: [
-      'Pre 1.13',
-      '1.13',
-      '2.0',
-      '2.1',
-      '2.2',
-      '2.3',
-      '2.4 LTS',
-      '2.5',
-      '2.6',
-      '2.7',
-      '2.8 LTS',
-      '2.9',
-      '2.10',
-      '2.11',
-      '2.12',
-    ],
-    title: 'Breakdown of Ember use by Version',
-  },
-
-  rawData: [
-    {
-      color: darkGrayColor,
-      label: '2016',
-      values: [
-        4 + 2 + 3 + 4 + 3 + 4 + 6 + 6,
-        36,
-        8,
-        6,
-        12,
-        27,
-        47,
-        3,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-      ],
-    },
-    {
-      color: emberOrange,
-      label: '2017',
-      values: [
-        9.46,
-        14.45,
-        2.97,
-        2.1,
-        2.02,
-        4.48,
-        11.29,
-        4.35,
-        4.48,
-        5.8,
-        21.2,
-        10.09,
-        21.6,
-        40.88,
-        19.31,
-      ],
-    },
-  ],
-}).highchartsOptions;
-
 const employmentSituation = new VerticalBarChart({
   chart: {
     categories: [
@@ -651,7 +583,6 @@ const priorVersionsData = new SplineChart({
 export default class EmberCommunitySurvey2017Controller extends Controller {
   chartHowlong = chartHowlong;
   chartSnapshotEmberDevelopers = chartSnapshotEmberDevelopers;
-  chartBreakdownByVersion = chartBreakdownByVersion;
   priorVersionsData = priorVersionsData;
   recommendingEmber = recommendingEmber;
   whenStarting = whenStarting;

--- a/app/controllers/ember-community-survey-2018.js
+++ b/app/controllers/ember-community-survey-2018.js
@@ -16,123 +16,6 @@ var color2017 = darkGrayColor;
 var color2018 = emberOrange;
 var colorFutureYear = lightGreenColor;
 
-const overallAdoption = new VerticalBarChart({
-  chart: {
-    categories: [
-      'Pre 1.13',
-      '1.13',
-      '2.0',
-      '2.1',
-      '2.2',
-      '2.3',
-      '2.4 LTS',
-      '2.5',
-      '2.6',
-      '2.7',
-      '2.8 LTS',
-      '2.9',
-      '2.10',
-      '2.11',
-      '2.12',
-      '2.13',
-      '2.14',
-      '2.15',
-      '2.16',
-      '2.17',
-      '2.18',
-      '3.0',
-    ],
-    title: 'Breakdown of Ember use by Version',
-  },
-
-  rawData: [
-    {
-      color: lightGrayColor,
-      label: '2016',
-      values: [
-        4 + 2 + 3 + 4 + 3 + 4 + 6 + 6,
-        36,
-        8,
-        6,
-        12,
-        27,
-        47,
-        3,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-      ],
-    },
-    {
-      color: darkGrayColor,
-      label: '2017',
-      values: [
-        9.46,
-        14.45,
-        2.97,
-        2.1,
-        2.02,
-        4.48,
-        11.29,
-        4.35,
-        4.48,
-        5.8,
-        21.2,
-        10.09,
-        21.6,
-        40.88,
-        19.31,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-      ],
-    },
-    {
-      color: emberOrange,
-      label: '2018',
-      values: [
-        5,
-        7.8,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        1.4,
-        7,
-        2,
-        2.7,
-        2.7,
-        11.4, // 2.12
-        7,
-        8,
-        6.6,
-        23.5, // 2.16
-        9.3,
-        43.2,
-        27.8, // 3.0
-      ],
-    },
-  ],
-}).highchartsOptions;
-
 const communityParticipation = new HorizontalBarChart({
   chart: {
     categories: [
@@ -859,7 +742,6 @@ const emberDataAdoption = new SplineChart({
 
 export default class EmberCommunitySurvey2018Controller extends Controller {
   newReleaseAdoption = newReleaseAdoption;
-  overallAdoption = overallAdoption;
   emberDataAdoption = emberDataAdoption;
   recommendingEmber = recommendingEmber;
   employerUsingEmber = employerUsingEmber;

--- a/app/controllers/ember-community-survey-2018.js
+++ b/app/controllers/ember-community-survey-2018.js
@@ -539,230 +539,323 @@ const demographicsRegion = new VerticalBarChart({
   ],
 }).highchartsOptions;
 
-function makeVersionChart(versionData, title) {
-  var seriesData = [];
+const newReleaseAdoption = new SplineChart({
+  chart: {
+    categories: [
+      '1.0',
+      '1.1',
+      '1.2',
+      '1.3',
+      '1.4',
+      '1.5',
+      '1.6',
+      '1.7',
+      '1.8',
+      '1.9',
+      '1.10',
+      '1.11',
+      '1.12',
+      '1.13',
+      '2.0',
+      '2.1',
+      '2.2',
+      '2.3',
+      '2.4',
+      '2.5',
+      '2.6',
+      '2.7',
+      '2.8',
+      '2.9',
+      '2.10',
+      '2.11',
+      '2.12',
+      '2.13',
+      '2.14',
+      '2.15',
+      '2.16',
+      '2.17',
+      '2.18',
+      '3.0',
+    ],
+    title: 'Which versions of Ember are used in your apps?',
+  },
 
-  for (var i = 0; i < versionData.length; ++i) {
-    var _series = {
-      label: versionData[i].year,
-      values: versionData[i].data.map(function (d) {
-        return d && d.value;
-      }),
-    };
-    if (versionData[i].color) {
-      _series.color = versionData[i].color;
-    }
-    seriesData.push(_series);
-  }
-
-  return new SplineChart({
-    chart: {
-      title: title,
-      subtitle: 'Releases Prior to Survey',
-      formatter: function () {
-        var releasesPrior = +this.x;
-        var s =
-          '<b>' +
-          +this.x +
-          ' Release' +
-          (releasesPrior !== 1 ? 's' : '') +
-          ' Prior to Survey</b>';
-        for (var i = 0; i < this.points.length; ++i) {
-          var point = this.points[i],
-            seriesName = point.series.name;
-          s +=
-            '<br/><span style="color:' +
-            point.color +
-            '">●</span>' +
-            seriesName +
-            ': ';
-          var labels;
-          for (var j = 0; j < versionData.length; ++j) {
-            if (versionData[j].year === seriesName) {
-              labels = versionData[j].data;
-            }
-          }
-          var label = labels[labels.length - 1 - releasesPrior].label;
-          s += label + ' Release (' + point.y + '%)';
-        }
-        return s;
-      },
-      categories: [
-        '13',
-        '12',
-        '11',
-        '10',
-        '9',
-        '8',
-        '7',
-        '6',
-        '5',
-        '4',
-        '3',
-        '2',
-        '1',
-        '0',
+  rawData: [
+    {
+      color: color2015,
+      label: '2015',
+      values: [
+        3, // '1.0'
+        1, // '1.1'
+        0.7, // '1.2'
+        2, // '1.3'
+        2.6, // '1.4'
+        3.9, // '1.5'
+        6.8, // '1.6'
+        15, // '1.7'
+        31.7, //'1.8'
+        39.5, // '1.9'
+        35, // '1.10'
+        null, // '1.11'
+        null, // '1.12'
+        null, // '1.13'
+        null, // '2.0'
+        null, // '2.1'
+        null, // '2.2'
+        null, // '2.3'
+        null, // '2.4'
+        null, // '2.5'
+        null, // '2.6'
+        null, // '2.7'
+        null, // '2.8'
+        null, // '2.9'
+        null, // '2.10'
+        null, // '2.11'
+        null, // '2.12'
+        null, // '2.13'
+        null, // '2.14'
+        null, // '2.15'
+        null, // '2.16'
+        null, // '2.17'
+        null, // '2.18'
+        null, // '3.0'
       ],
     },
-    rawData: seriesData,
-  }).highchartsOptions;
-}
+    {
+      color: color2016,
+      label: '2016',
+      values: [
+        null, // '1.0'
+        null, // '1.1'
+        null, // '1.2'
+        null, // '1.3'
+        null, // '1.4'
+        null, // '1.5'
+        1.8, // '1.6'
+        2.7, // '1.7'
+        3.5, //'1.8'
+        2.6, // '1.9'
+        3.9, // '1.10'
+        6, // '1.11'
+        5.8, // '1.12'
+        36, // '1.13'
+        8.2, // '2.0'
+        6.3, // '2.1'
+        11.5, // '2.2'
+        27, // '2.3'
+        47, // '2.4'
+        null, // '2.5'
+        null, // '2.6'
+        null, // '2.7'
+        null, // '2.8'
+        null, // '2.9'
+        null, // '2.10'
+        null, // '2.11'
+        null, // '2.12'
+        null, // '2.13'
+        null, // '2.14'
+        null, // '2.15'
+        null, // '2.16'
+        null, // '2.17'
+        null, // '2.18'
+        null, // '3.0'
+      ],
+    },
+    {
+      color: color2017,
+      label: '2017',
+      values: [
+        null, // '1.0'
+        null, // '1.1'
+        null, // '1.2'
+        null, // '1.3'
+        null, // '1.4'
+        null, // '1.5'
+        null, // '1.6'
+        null, // '1.7'
+        null, //'1.8'
+        null, // '1.9'
+        null, // '1.10'
+        null, // '1.11'
+        null, // '1.12'
+        14.5, // '1.13'
+        3, // '2.0'
+        2.1, // '2.1'
+        2, // '2.2'
+        4.5, // '2.3'
+        11.3, // '2.4'
+        4.4, // '2.5'
+        4.5, // '2.6'
+        5.8, // '2.7'
+        21.2, // '2.8'
+        10, // '2.9'
+        22, // '2.10'
+        41, // '2.11'
+        19.3, // '2.12'
+        null, // '2.13'
+        null, // '2.14'
+        null, // '2.15'
+        null, // '2.16'
+        null, // '2.17'
+        null, // '2.18'
+        null, // '3.0'
+      ],
+    },
+    {
+      color: color2018,
+      label: '2018',
+      values: [
+        null, // '1.0'
+        null, // '1.1'
+        null, // '1.2'
+        null, // '1.3'
+        null, // '1.4'
+        null, // '1.5'
+        null, // '1.6'
+        null, // '1.7'
+        null, //'1.8'
+        null, // '1.9'
+        null, // '1.10'
+        null, // '1.11'
+        null, // '1.12'
+        null, // '1.13'
+        null, // '2.0'
+        null, // '2.1'
+        null, // '2.2'
+        null, // '2.3'
+        null, // '2.4'
+        null, // '2.5'
+        8.6, // '2.6' (2.0-2.6)
+        1.5, // '2.7'
+        7.1, // '2.8'
+        2.1, // '2.9'
+        2.8, // '2.10'
+        2.7, // '2.11'
+        11.6, // '2.12'
+        7.1, // '2.13'
+        8.1, // '2.14'
+        6.7, // '2.15'
+        23.8, // '2.16'
+        9.4, // '2.17'
+        43.8, // '2.18'
+        28.2, // '3.0'
+      ],
+    },
+  ],
+}).highchartsOptions;
 
-var emberVersionData = [
-  {
-    year: '2015',
-    color: color2015,
-    data: [
-      null,
-      null,
-      null,
-      { value: 3, label: '1.0' },
-      { value: 1, label: '1.1' },
-      { value: 0.7, label: '1.2' },
-      { value: 2, label: '1.3' },
-      { value: 2.6, label: '1.4' },
-      { value: 3.9, label: '1.5' },
-      { value: 6.8, label: '1.6' },
-      { value: 15, label: '1.7' },
-      { value: 31.7, label: '1.8' },
-      { value: 39.5, label: '1.9' },
-      { value: 35, label: '1.10' },
+const emberDataAdoption = new SplineChart({
+  chart: {
+    categories: [
+      '1.13',
+      '2.0',
+      '2.1',
+      '2.2',
+      '2.3',
+      '2.4',
+      '2.5',
+      '2.6',
+      '2.7',
+      '2.8',
+      '2.9',
+      '2.10',
+      '2.11',
+      '2.12',
+      '2.13',
+      '2.14',
+      '2.15',
+      '2.16',
+      '2.17',
+      '2.18',
+      '3.0',
     ],
+    title: 'Which versions of Ember Data are used in your apps?',
   },
-  {
-    year: '2016',
-    color: color2016,
-    data: [
-      { value: 1.8, label: '1.6' },
-      { value: 2.7, label: '1.7' },
-      { value: 3.5, label: '1.8' },
-      { value: 2.6, label: '1.9' },
-      { value: 3.9, label: '1.10' },
-      { value: 6, label: '1.11' },
-      { value: 5.8, label: '1.12' },
-      { value: 36, label: '1.13 LTS' },
-      { value: 8.2, label: '2.0' },
-      { value: 6.3, label: '2.1' },
-      { value: 11.5, label: '2.2' },
-      { value: 27, label: '2.3' },
-      { value: 47, label: '2.4 LTS' },
-      null,
-    ],
-  },
-  {
-    year: '2017',
-    color: color2017,
-    data: [
-      { value: 14.5, label: '1.13 LTS' },
-      { value: 3, label: '2.0' },
-      { value: 2.1, label: '2.1' },
-      { value: 2, label: '2.2' },
-      { value: 4.5, label: '2.3' },
-      { value: 11.3, label: '2.4 LTS' },
-      { value: 4.4, label: '2.5' },
-      { value: 4.5, label: '2.6' },
-      { value: 5.8, label: '2.7' },
-      { value: 21.2, label: '2.8 LTS' },
-      { value: 10, label: '2.9' },
-      { value: 22, label: '2.10' },
-      { value: 41, label: '2.11' },
-      { value: 19.3, label: '2.12 LTS' },
-    ],
-  },
-  {
-    year: '2018',
-    color: color2018,
-    data: [
-      { value: 8.6, label: '2.0-2.6' },
-      { value: 1.5, label: '2.7' },
-      { value: 7.1, label: '2.8 LTS' },
-      { value: 2.1, label: '2.9' },
-      { value: 2.8, label: '2.10' },
-      { value: 2.7, label: '2.11' },
-      { value: 11.6, label: '2.12 LTS' },
-      { value: 7.1, label: '2.13' },
-      { value: 8.1, label: '2.14' },
-      { value: 6.7, label: '2.15' },
-      { value: 23.8, label: '2.16 LTS' },
-      { value: 9.4, label: '2.17' },
-      { value: 43.8, label: '2.18 LTS' },
-      { value: 28.2, label: '3.0' },
-    ],
-  },
-];
 
-const newReleaseAdoption = makeVersionChart(
-  emberVersionData,
-  'Which version(s) of Ember are used in your apps?'
-);
-
-var emberDataVersionData = [
-  {
-    year: '2016',
-    color: color2016,
-    data: [
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      { value: 27, label: '1.13' },
-      { value: 6, label: '2.0' },
-      { value: 4, label: '2.1' },
-      { value: 8, label: '2.2' },
-      { value: 21, label: '2.3' },
-      { value: 42, label: '2.4' },
-      null,
-    ],
-  },
-  {
-    year: '2017',
-    color: color2017,
-    data: [
-      { value: 9, label: '1.13' },
-      { value: 2.15, label: '2.0' },
-      { value: 2.1, label: '2.1' },
-      { value: 1.5, label: '2.2' },
-      { value: 2.8, label: '2.3' },
-      { value: 7, label: '2.4' },
-      { value: 3, label: '2.5' },
-      { value: 4, label: '2.6' },
-      { value: 4, label: '2.7' },
-      { value: 13.8, label: '2.8' },
-      { value: 7, label: '2.9' },
-      { value: 21.6, label: '2.10' },
-      { value: 34.9, label: '2.11' },
-      { value: 17, label: 'stable (2.12)' },
-    ],
-  },
-  {
-    year: '2018',
-    color: color2018,
-    data: [
-      { value: 5.9, label: '2.0-2.6' },
-      { value: 1, label: '2.7' },
-      { value: 5.2, label: '2.8' },
-      { value: 2, label: '2.9' },
-      { value: 2.3, label: '2.10' },
-      { value: 2.5, label: '2.11' },
-      { value: 12.5, label: '2.12' },
-      { value: 6.2, label: '2.13' },
-      { value: 6.2, label: '2.14' },
-      { value: 0, label: '2.15' },
-      { value: 17.2, label: '2.16' },
-      { value: 6.8, label: '2.17' },
-      { value: 35.8, label: '2.18' },
-      { value: 21.5, label: '3.0' },
-    ],
-  },
-];
-
-const emberDataAdoption = makeVersionChart(
-  emberDataVersionData,
-  'Which versions of Ember Data are used in your apps?'
-);
+  rawData: [
+    {
+      color: color2016,
+      label: '2016',
+      values: [
+        27, // '1.13'
+        6, // '2.0'
+        4, // '2.1'
+        8, // '2.2'
+        21, // '2.3'
+        42, // '2.4'
+        null, // '2.5'
+        null, // '2.6'
+        null, // '2.7'
+        null, // '2.8'
+        null, // '2.9'
+        null, // '2.10'
+        null, // '2.11'
+        null, // '2.12'
+        null, // '2.13'
+        null, // '2.14'
+        null, // '2.15'
+        null, // '2.16'
+        null, // '2.17'
+        null, // '2.18'
+        null, // '3.0'
+      ],
+    },
+    {
+      color: color2017,
+      label: '2017',
+      values: [
+        9, // '1.13'
+        2.15, // '2.0'
+        2.1, // '2.1'
+        1.5, // '2.2'
+        2.8, // '2.3'
+        7, // '2.4'
+        3, // '2.5'
+        4, // '2.6'
+        4, // '2.7'
+        13.8, // '2.8'
+        7, // '2.9'
+        21.6, // '2.10'
+        34.9, // '2.11'
+        17, // '2.12'
+        null, // '2.13'
+        null, // '2.14'
+        null, // '2.15'
+        null, // '2.16'
+        null, // '2.17'
+        null, // '2.18'
+        null, // '3.0'
+      ],
+    },
+    {
+      color: color2018,
+      label: '2018',
+      values: [
+        null, // '1.13'
+        null, // '2.0'
+        null, // '2.1'
+        null, // '2.2'
+        null, // '2.3'
+        null, // '2.4'
+        null, // '2.5'
+        5.9, // '2.6' (2.0-2.6)
+        1, // '2.7'
+        5.2, // '2.8'
+        2, // '2.9'
+        2.3, // '2.10'
+        2.5, // '2.11'
+        12.5, // '2.12'
+        6.2, // '2.13'
+        6.2, // '2.14'
+        0, // '2.15'
+        17.2, // '2.16'
+        6.8, // '2.17'
+        35.8, // '2.18'
+        21.5, // '3.0'
+      ],
+    },
+  ],
+}).highchartsOptions;
 
 export default class EmberCommunitySurvey2018Controller extends Controller {
   newReleaseAdoption = newReleaseAdoption;

--- a/app/templates/ember-community-survey-2017.hbs
+++ b/app/templates/ember-community-survey-2017.hbs
@@ -17,19 +17,10 @@
   @sectionTitle="Ember Version"
 >
   <:charts>
-    <div>
-      <Highcharts
-        @chartOptions={{this.chartHowlong.options}}
-        @data={{this.chartHowlong.data}}
-      />
-    </div>
-
-    <div class="mt-3">
-      <Highcharts
-        @chartOptions={{this.chartBreakdownByVersion.options}}
-        @data={{this.chartBreakdownByVersion.data}}
-      />
-    </div>
+    <Highcharts
+      @chartOptions={{this.chartHowlong.options}}
+      @data={{this.chartHowlong.data}}
+    />
   </:charts>
 
   <:body>

--- a/app/templates/ember-community-survey-2018.hbs
+++ b/app/templates/ember-community-survey-2018.hbs
@@ -17,19 +17,10 @@
   @sectionTitle="Ember Version"
 >
   <:charts>
-    <div>
-      <Highcharts
-        @chartOptions={{this.newReleaseAdoption.options}}
-        @data={{this.newReleaseAdoption.data}}
-      />
-    </div>
-
-    <div class="mt-3">
-      <Highcharts
-        @chartOptions={{this.overallAdoption.options}}
-        @data={{this.overallAdoption.data}}
-      />
-    </div>
+    <Highcharts
+      @chartOptions={{this.newReleaseAdoption.options}}
+      @data={{this.newReleaseAdoption.data}}
+    />
   </:charts>
 
   <:body>

--- a/app/utils/highcharts/spline-chart.js
+++ b/app/utils/highcharts/spline-chart.js
@@ -1,5 +1,5 @@
 /*
- https://api.highcharts.com/highcharts/plotOptions.spline
+  https://api.highcharts.com/highcharts/plotOptions.spline
 */
 export default class SplineChart {
   constructor({ chart, rawData }) {
@@ -18,6 +18,14 @@ export default class SplineChart {
           type: 'spline',
         },
 
+        plotOptions: {
+          series: {
+            marker: {
+              enabled: false,
+            },
+          },
+        },
+
         subtitle: {
           text: chart.subtitle,
         },
@@ -27,17 +35,7 @@ export default class SplineChart {
         },
 
         tooltip: {
-          crosshairs: true,
-          formatter: chart.tooltip,
-          shared: true,
-        },
-
-        plotOptions: {
-          series: {
-            marker: {
-              enabled: false,
-            },
-          },
+          pointFormat: '{series.name}: {point.y:.1f}%',
         },
 
         xAxis: {
@@ -46,8 +44,9 @@ export default class SplineChart {
         },
 
         yAxis: {
+          min: 0,
           title: {
-            text: 'Percent',
+            text: 'Percent of responses',
           },
         },
       },

--- a/tests/unit/utils/highcharts/spline-chart-test.js
+++ b/tests/unit/utils/highcharts/spline-chart-test.js
@@ -6,21 +6,38 @@ import { module, test } from 'qunit';
 module('Unit | Utility | highcharts/spline-chart', function () {
   module('SplineChart', function () {
     test('highchartsOptions returns an options object', function (assert) {
-      const noOp = () => {};
-
       const { options } = new SplineChart({
         chart: {
-          categories: ['6', '5', '4', '3', '2', '1', '0'],
+          categories: [
+            '1.13',
+            '2.0',
+            '2.1',
+            '2.2',
+            '2.3',
+            '2.4',
+            '2.5',
+            '2.6',
+            '2.7',
+            '2.8',
+            '2.9',
+            '2.10',
+            '2.11',
+            '2.12',
+          ],
           title: 'Which versions of Ember Data are used in your apps?',
-          subtitle: 'Some subtitle',
-          tooltip: noOp,
         },
 
         rawData: [
           {
+            color: '#4b4b4b',
             label: '2016',
-            color: '#1E1E1E',
             values: [
+              27,
+              6,
+              4,
+              8,
+              21,
+              42,
               null,
               null,
               null,
@@ -28,40 +45,31 @@ module('Unit | Utility | highcharts/spline-chart', function () {
               null,
               null,
               null,
-              { value: 27, label: '1.13' },
-              { value: 6, label: '2.0' },
-              { value: 4, label: '2.1' },
-              { value: 8, label: '2.2' },
-              { value: 21, label: '2.3' },
-              { value: 42, label: '2.4' },
               null,
             ],
           },
           {
+            color: '#f23818',
             label: '2017',
-            color: '#FFFFFF',
             values: [
-              { value: 9, label: '1.13' },
-              { value: 2.15, label: '2.0' },
-              { value: 2.1, label: '2.1' },
-              { value: 1.5, label: '2.2' },
-              { value: 2.8, label: '2.3' },
-              { value: 7, label: '2.4' },
-              { value: 3, label: '2.5' },
-              { value: 4, label: '2.6' },
-              { value: 4, label: '2.7' },
-              { value: 13.8, label: '2.8' },
-              { value: 7, label: '2.9' },
-              { value: 21.6, label: '2.10' },
-              { value: 34.9, label: '2.11' },
-              { value: 17, label: 'stable (2.12)' },
+              9,
+              2.15,
+              2.1,
+              1.5,
+              2.8,
+              7,
+              3,
+              4,
+              4,
+              13.8,
+              7,
+              21.6,
+              34.9,
+              17,
             ],
           },
         ],
       }).highchartsOptions;
-
-      // Don't check tooltip.formatter (a function) in tests
-      delete options.tooltip.formatter;
 
       assert.deepEqual(
         options,
@@ -79,7 +87,7 @@ module('Unit | Utility | highcharts/spline-chart', function () {
           },
 
           subtitle: {
-            text: 'Some subtitle',
+            text: undefined,
           },
 
           title: {
@@ -87,18 +95,33 @@ module('Unit | Utility | highcharts/spline-chart', function () {
           },
 
           tooltip: {
-            crosshairs: true,
-            shared: true,
+            pointFormat: '{series.name}: {point.y:.1f}%',
           },
 
           xAxis: {
-            categories: ['6', '5', '4', '3', '2', '1', '0'],
+            categories: [
+              '1.13',
+              '2.0',
+              '2.1',
+              '2.2',
+              '2.3',
+              '2.4',
+              '2.5',
+              '2.6',
+              '2.7',
+              '2.8',
+              '2.9',
+              '2.10',
+              '2.11',
+              '2.12',
+            ],
             type: 'category',
           },
 
           yAxis: {
+            min: 0,
             title: {
-              text: 'Percent',
+              text: 'Percent of responses',
             },
           },
         },
@@ -111,9 +134,15 @@ module('Unit | Utility | highcharts/spline-chart', function () {
     test('returns the series object', function (assert) {
       const rawData = [
         {
+          color: '#4b4b4b',
           label: '2016',
-          color: '#555',
           values: [
+            27,
+            6,
+            4,
+            8,
+            21,
+            42,
             null,
             null,
             null,
@@ -121,34 +150,13 @@ module('Unit | Utility | highcharts/spline-chart', function () {
             null,
             null,
             null,
-            { value: 27, label: '1.13' },
-            { value: 6, label: '2.0' },
-            { value: 4, label: '2.1' },
-            { value: 8, label: '2.2' },
-            { value: 21, label: '2.3' },
-            { value: 42, label: '2.4' },
             null,
           ],
         },
         {
+          color: '#f23818',
           label: '2017',
-          color: '#444',
-          values: [
-            { value: 9, label: '1.13' },
-            { value: 2.15, label: '2.0' },
-            { value: 2.1, label: '2.1' },
-            { value: 1.5, label: '2.2' },
-            { value: 2.8, label: '2.3' },
-            { value: 7, label: '2.4' },
-            { value: 3, label: '2.5' },
-            { value: 4, label: '2.6' },
-            { value: 4, label: '2.7' },
-            { value: 13.8, label: '2.8' },
-            { value: 7, label: '2.9' },
-            { value: 21.6, label: '2.10' },
-            { value: 34.9, label: '2.11' },
-            { value: 17, label: 'stable (2.12)' },
-          ],
+          values: [9, 2.15, 2.1, 1.5, 2.8, 7, 3, 4, 4, 13.8, 7, 21.6, 34.9, 17],
         },
       ];
 
@@ -158,14 +166,16 @@ module('Unit | Utility | highcharts/spline-chart', function () {
 
       // Check series 1
       assert.deepEqual(
+        series[0],
         {
-          color: series[0].color,
-          data: series[0].data,
-          year: series[0].name,
-        },
-        {
-          color: '#555',
+          color: '#4b4b4b',
           data: [
+            27,
+            6,
+            4,
+            8,
+            21,
+            42,
             null,
             null,
             null,
@@ -173,45 +183,20 @@ module('Unit | Utility | highcharts/spline-chart', function () {
             null,
             null,
             null,
-            { value: 27, label: '1.13' },
-            { value: 6, label: '2.0' },
-            { value: 4, label: '2.1' },
-            { value: 8, label: '2.2' },
-            { value: 21, label: '2.3' },
-            { value: 42, label: '2.4' },
             null,
           ],
-          year: '2016',
+          name: '2016',
         },
         'We get the correct data for the 1st series.'
       );
 
       // Check series 2
       assert.deepEqual(
+        series[1],
         {
-          color: series[1].color,
-          data: series[1].data,
-          year: series[1].name,
-        },
-        {
-          color: '#444',
-          data: [
-            { value: 9, label: '1.13' },
-            { value: 2.15, label: '2.0' },
-            { value: 2.1, label: '2.1' },
-            { value: 1.5, label: '2.2' },
-            { value: 2.8, label: '2.3' },
-            { value: 7, label: '2.4' },
-            { value: 3, label: '2.5' },
-            { value: 4, label: '2.6' },
-            { value: 4, label: '2.7' },
-            { value: 13.8, label: '2.8' },
-            { value: 7, label: '2.9' },
-            { value: 21.6, label: '2.10' },
-            { value: 34.9, label: '2.11' },
-            { value: 17, label: 'stable (2.12)' },
-          ],
-          year: '2017',
+          color: '#f23818',
+          data: [9, 2.15, 2.1, 1.5, 2.8, 7, 3, 4, 4, 13.8, 7, 21.6, 34.9, 17],
+          name: '2017',
         },
         'We get the correct data for the 2nd series.'
       );


### PR DESCRIPTION
## Description

This pull request continues work from #838.

Until now, we rendered 4 highly customized spline charts in 2017 and 2018 survey results. These charts superimposed graphs in an attempt to indicate how a trend might have changed over time.

<img width="1060" alt="what spline chart class can render currently" src="https://user-images.githubusercontent.com/16869656/114916614-4a274c00-9e25-11eb-9b81-89d974c766c8.png">

The problem with this approach is the high customization. We overrode the default tooltip with a complex, untested function and could not reuse the spline chart class to visualize any other data application.

A simpler approach can reduce the bundle size (by ~1.2 KB, gzipped), allow us to reuse the class for other data applications, and increase maintainbility. In addition, the new graph can help a general public understand the message that we want to tell with historical data:

<img width="1060" alt="what spline chart class will render from now on" src="https://user-images.githubusercontent.com/16869656/114917516-519b2500-9e26-11eb-8efc-de0d24122ff0.png">
