### PR TITLE
Update Ember Times link to new Substack site

### DIFF
--- a/app/templates/community/index.hbs
+++ b/app/templates/community/index.hbs
@@ -34,7 +34,7 @@
     <div class="lg:col-4">
       <h2 id="section-latest-news">Stay Up to Date with the Latest News</h2>
       <p>
-        <a href="https://the-emberjs-times.ongoodbits.com/">Ember.js Times</a> &mdash; follow the progress of new features in the Ember ecosystem, requests for community input (RFCs), and calls for contributors
+        <a href="https://embertimes.substack.com/">Ember.js Times</a> &mdash; follow the progress of new features in the Ember ecosystem, requests for community input (RFCs), and calls for contributors
       </p>
       <p>
         <a href="http://emberweekly.com/">Ember Weekly</a> &mdash; a curated list of Ember learning resources (podcasts, videos, blog posts, books, and more)


### PR DESCRIPTION
It looks like the Ember Times moved from Goodbits to Substack at some point. This updates the link on the community page.