### PR TITLE
Updated beta release page

### DIFF
--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -6,8 +6,8 @@ filter:
   - /ember-template-compiler/
 repo: emberjs/ember.js
 initialVersion: 3.26.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-lastRelease: 3.27.0-beta.3 # Manually update
-futureVersion: 3.27.0-beta.4 # Manually update
+lastRelease: 3.27.0-beta.4 # Manually update
+futureVersion: 3.27.0-beta.5 # Manually update
 finalVersion: 3.27.0 # Manually update
 channel: beta
 cycleEstimatedFinishDate: 2021-05-03 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release


### PR DESCRIPTION
## Description

The beta release page currently shows that `3.27b3` is the latest beta version for `ember-source`, although `3.27.5` has been released. For posterity, the incongruence was due to a delay in `ember-cli@3.27` release.

In the meantime, let's update the beta version to show `3.27b4`.

Related discussion: https://github.com/ember-learn/ember-website/issues/261#issuecomment-864232374