### PR TITLE
Update release dates for 3.28

### DIFF
--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -5,14 +5,14 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.26.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-lastRelease: 3.27.0-beta.4 # Manually update
-futureVersion: 3.27.0-beta.5 # Manually update
-finalVersion: 3.27.0 # Manually update
+initialVersion: 3.27.0 # Manually update, the prior version to the current beta. See https://libraries.io/npm/ember-source throughout
+lastRelease: 3.28.0-beta.6 # Manually update
+futureVersion: 3.28.0-beta.7 # Manually update
+finalVersion: 3.28.0 # Manually update
 channel: beta
-cycleEstimatedFinishDate: 2021-05-03 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
-date: 2021-03-22 # Manually update, get date for `initialVersion`
-nextDate: 2021-05-03 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+cycleEstimatedFinishDate: 2021-08-09 12:00:00 # Manually update, the expected date of the finalVersion release
+date: 2021-05-03 # Manually update, get date for `initialVersion`
+nextDate: 2021-07-19 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.26.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-initialReleaseDate: 2021-03-22 # Manually update
-lastRelease: 3.26.1 # Manually update
-futureVersion: 3.26.2 # Manually update
+initialVersion: 3.27.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+initialReleaseDate: 2021-05-03 # Manually update
+lastRelease: 3.27.5 # Manually update
+futureVersion: 3.27.6 # Manually update
 channel: release
-date: 2021-04-12 # Manually update, is today's date
+date: 2021-07-13 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/tests/integration/data/releases-test.js
+++ b/tests/integration/data/releases-test.js
@@ -11,7 +11,7 @@ let expectedReleaseDates = {
   '3.25.0': new Date('2021-02-08 12:00:00 GMT'),
   '3.26.0': new Date('2021-03-22 12:00:00 GMT'),
   '3.27.0': new Date('2021-05-03 12:00:00 GMT'),
-  '3.28.0': new Date('2021-06-14 12:00:00 GMT'),
+  '3.28.0': new Date('2021-08-09 12:00:00 GMT'),
 };
 
 module('Integration | Data | releases', function (hooks) {


### PR DESCRIPTION
These dates should align with https://github.com/ember-learn/ember-blog/pull/995, I would appreciate a gut check from @kategengler on them.