### PR TITLE
Make ember-users images responsive

### DIFF
--- a/app/helpers/file-extension.js
+++ b/app/helpers/file-extension.js
@@ -1,0 +1,6 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function fileExtension([filename]) {
+  // taken from https://stackoverflow.com/a/12900504 for optimal performance
+  return filename.slice(((filename.lastIndexOf('.') - 1) >>> 0) + 2);
+});

--- a/app/templates/ember-users.hbs
+++ b/app/templates/ember-users.hbs
@@ -25,11 +25,18 @@
       }}
         <li>
           <a href={{user.url}} rel="nofollow noopener noreferrer" target="_blank" class="well well-16/9">
-            <img
-              alt={{user.name}}
-              src="/images/users/{{user.image}}"
-              loading="lazy"
-            >
+            {{#if (eq (file-extension user.image) "svg")}}
+              <img
+                alt={{user.name}}
+                src="/images/users/{{user.image}}"
+                loading="lazy"
+              >
+            {{else}}
+              <ResponsiveImage
+                @src="/images/users/{{user.image}}"
+                alt={{user.name}}
+              />
+            {{/if}}
           </a>
         </li>
       {{/each}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -103,6 +103,18 @@ module.exports = function (defaults) {
           // don't scale images, just copy as-is in dev mode, to not slow down the build
           justCopy: process.env.EMBER_ENV !== 'production',
         },
+        {
+          include: 'images/users/*.png',
+          widths: [
+            58, // mobile
+            116, // mobile 2x
+            88, // desktop
+            176, // desktop 2x, iPhone 2x
+          ],
+          removeSource: true,
+          // don't scale images, just copy as-is in dev mode, to not slow down the build
+          justCopy: process.env.EMBER_ENV !== 'production',
+        },
       ],
     },
   });

--- a/tests/integration/helpers/file-extension-test.js
+++ b/tests/integration/helpers/file-extension-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | file-extension', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it extracts the file extension', async function (assert) {
+    await render(hbs`
+      <div data-test-value>
+        {{file-extension "some.file.png"}}
+      </div>
+    `);
+
+    assert
+      .dom('[data-test-value]')
+      .hasText('png', 'We get the correct file extension.');
+  });
+});


### PR DESCRIPTION
It required adding a conditional using a custom helper to check for SVGs used as the company logo (by a handful of companies), in which case responsive images using `<picture>` and `srcset` do not make sense.

*Actually*, ideally all company logos should be SVGs IMO. But we cannot change that here without requiring all users to upload new logo files...