### PR TITLE
Replaced @percy/exec-action (deprecated) with @percy/cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,7 @@ jobs:
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
 
       - name: Test
-        uses: percy/exec-action@v0.3.1
-        with:
-          custom-command: npm test
+        run: npx percy exec -- yarn test
         env:
           PERCY_PARALLEL_NONCE: ${{ env.PERCY_PARALLEL_NONCE }}
           PERCY_PARALLEL_TOTAL: ${{ env.PERCY_PARALLEL_TOTAL }}


### PR DESCRIPTION
## References

- https://github.com/percy/exec-action#deprecated