### PR TITLE
Provided the latest minor releases for Ember 3.28

### DIFF
--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -6,8 +6,8 @@ filter:
   - /ember-template-compiler/
 repo: emberjs/ember.js
 initialVersion: 3.28.0 # Manually update, the prior version to the current beta. See https://libraries.io/npm/ember-source throughout
-lastRelease: 4.0.0-beta.3 # Manually update
-futureVersion: 4.0.0-beta.4 # Manually update
+lastRelease: 4.0.0-beta.10 # Manually update
+futureVersion: 4.0.0-beta.11 # Manually update
 finalVersion: 4.0.0 # Manually update
 channel: beta
 cycleEstimatedFinishDate: 2021-09-20 12:00:00 # Manually update, the expected date of the finalVersion release

--- a/data/project/ember/lts.md
+++ b/data/project/ember/lts.md
@@ -7,8 +7,8 @@ filter:
 repo: emberjs/ember.js
 initialVersion: 3.24.0
 initialReleaseDate: 2020-12-28
-lastRelease: 3.24.5
-futureVersion: 3.24.6
+lastRelease: 3.24.6
+futureVersion: 3.24.7
 channel: lts
 date: 2021-02-25
 changelogPath: CHANGELOG.md

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -7,8 +7,8 @@ filter:
 repo: emberjs/ember.js
 initialVersion: 3.28.0 # Manually update, see https://libraries.io/npm/ember-source throughout
 initialReleaseDate: 2021-08-10 # Manually update
-lastRelease: 3.28.1 # Manually update
-futureVersion: 3.28.2 # Manually update
+lastRelease: 3.28.6 # Manually update
+futureVersion: 3.28.7 # Manually update
 channel: release
 date: 2021-09-07 # Manually update, is today's date
 changelogPath: CHANGELOG.md

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -4,8 +4,8 @@ baseFileName: ember-data
 filter:
  - /ember-data\./
 repo: emberjs/data
-lastRelease: 4.0.0-beta.2 # Manually update, see https://libraries.io/npm/ember-data throughout
-futureVersion: 4.0.0-beta.3 # Manually update
+lastRelease: 4.0.0-beta.4 # Manually update, see https://libraries.io/npm/ember-data throughout
+futureVersion: 4.0.0-beta.5 # Manually update
 finalVersion: 4.0.0 # Manually update
 channel: beta
 date: 2021-09-05 # Manually update, get date for `lastRelease` 

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -6,8 +6,8 @@ filter:
 repo: emberjs/data
 initialVersion: 3.28.0 # Manually update, see https://libraries.io/npm/ember-data throughout
 initialReleaseDate: 2021-08-20 # Manually update, get date for `initialVersion`
-lastRelease: 3.28.3 # Manually update
-futureVersion: 3.28.4 # Manually update
+lastRelease: 3.28.5 # Manually update
+futureVersion: 3.28.6 # Manually update
 channel: release
 date: 2021-09-07 # Manually update, is today's date
 changelogPath: CHANGELOG.md


### PR DESCRIPTION
## Description

In #878, the update to https://emberjs.com/releases/ resulted in displaying the latest minor version. Unfortunately, the page can become out-of-date when we don't regularly update the data files.

<img width="1028" alt="The page shows 3.28.1 as the latest minor release, but it should be 3.28.6." src="https://user-images.githubusercontent.com/16869656/143382177-0920e47a-9307-4929-8c1d-eccb1741adcf.png">

In a separate pull request, I will remove the unused fields in the data files for easier maintenance. To my knowledge, some fields had been used to provide data to the `<Releases::ReleaseTimeline>` component, which no longer exists.