### PR TITLE
Document when a release is ready

### DIFF
--- a/app/templates/releases/index.hbs
+++ b/app/templates/releases/index.hbs
@@ -27,6 +27,14 @@
   releases.
 </p>
 
+<h2>How do you know when a release is complete?</h2>
+<p>
+  For major and minor stable releases, a release is complete when the 
+  <a href="">Release blog post</a> is published. 
+  That is your indicator that all core packages have been published and supporting resources 
+  like documentation are available.
+</p>
+
 <h2>Strategy</h2>
 <p>
   Ember is built by people who are at the front lines of building and upgrading their company's apps.


### PR DESCRIPTION
This is a draft. Feedback encouraged!

**Why should this section exist?**
It can be confusing for users to see that a release tag exists on a project, but there are no docs, or that ember itself has a release but not ember data. This gives us something to link to.

To do:
- [ ] fill in the url
- [ ] share with core teams to make sure we are all on the same page
- [ ] iterate based on feedback
- [ ] Choose a better section title