### PR TITLE
Adding IE11 to compilation targets

### DIFF
--- a/config/targets.js
+++ b/config/targets.js
@@ -14,12 +14,12 @@ const browsers = [
 // If you need IE11 support on a version of Ember that still offers support
 // for it, uncomment the code block below.
 //
-// const isCI = Boolean(process.env.CI);
-// const isProduction = process.env.EMBER_ENV === 'production';
-//
-// if (isCI || isProduction) {
-//   browsers.push('ie 11');
-// }
+const isCI = Boolean(process.env.CI);
+const isProduction = process.env.EMBER_ENV === 'production';
+
+if (isCI || isProduction) {
+  browsers.push('ie 11');
+}
 
 module.exports = {
   browsers,


### PR DESCRIPTION
At the moment the website's navigation does not work with JavaScript disabled.
This is conjunction with the lack of support for IE11 feels to me too punitive of people on older browsers and a matter of accessibility.

While this change won't help in scenarios where JavaScript is disabled, it should enable older browser to access our main website. The Guides still have IE11 in their targets, as does API Docs.