### PR TITLE
Pin npm 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "algoliasearch"
   ],
   "volta": {
-    "node": "14.16.0"
+    "node": "14.16.0",
+    "npm": "8.5.3"
   }
 }


### PR DESCRIPTION
I was tracking down the lint fail for mansona/npm-lockfile-version and noticed that I was using npm v6 and thus changing the lockfile to v1. Pinning npm to v8 prevents this for volta users.