### PR TITLE
Use idiomatic caching for teams list

### DIFF
--- a/app/controllers/teams.js
+++ b/app/controllers/teams.js
@@ -1,13 +1,13 @@
 import Controller from '@ember/controller';
-import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
+import { cached } from '@glimmer/tracking';
 
-function inTeam(team) {
-  return (teamMember) => (teamMember.teams ?? []).includes(team);
-}
+const inTeam = (team) => (teamMember) =>
+  (teamMember.teams ?? []).includes(team);
 
 export default class TeamsController extends Controller {
-  #sortedTeamMembers = createCache(() => {
-    const teamMembers = (this.model ?? []).toArray();
+  @cached
+  get sortedTeamMembers() {
+    const teamMembers = this.model?.slice() ?? [];
 
     return teamMembers.sort((teamMember1, teamMember2) => {
       const surname1 = teamMember1.last ?? '';
@@ -24,10 +24,6 @@ export default class TeamsController extends Controller {
 
       return comparisonResult;
     });
-  });
-
-  get sortedTeamMembers() {
-    return getValue(this.#sortedTeamMembers);
   }
 
   get alumniTeamMembers() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "ember-a11y-testing": "^4.3.0",
         "ember-auto-import": "^2.2.4",
         "ember-body-class": "^2.1.1",
+        "ember-cached-decorator-polyfill": "^0.1.4",
         "ember-cli": "~3.28.4",
         "ember-cli-app-version": "^5.0.0",
         "ember-cli-babel": "^7.26.6",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ember-a11y-testing": "^4.3.0",
     "ember-auto-import": "^2.2.4",
     "ember-body-class": "^2.1.1",
+    "ember-cached-decorator-polyfill": "^0.1.4",
     "ember-cli": "~3.28.4",
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.26.6",


### PR DESCRIPTION
This caching isn't even really *necessary*, but it doesn't hurt; in any case, if we want to use caching here, it makes sense to do it in the idiomatic way we would recommend instead of using the primitives for it.