### PR TITLE
Remove social link underline

### DIFF
--- a/app/components/teams/team/member.hbs
+++ b/app/components/teams/team/member.hbs
@@ -14,7 +14,7 @@
     {{@member.name}}
   </div>
 
-  <div>
+  <div class="social-links">
     {{#if @member.github}}
       <a
         aria-label="{{@member.name}} Github Profile"

--- a/app/styles/components/team-list.css
+++ b/app/styles/components/team-list.css
@@ -3,3 +3,7 @@
   height: 100px;
   border-radius: 50%;
 }
+
+.social-links .icon {
+  background: none;
+}


### PR DESCRIPTION
Remove unwanted pink underline from social links on Team page

Fixes #893 