### PR TITLE
Refactored chart utilities, conditionally hid the chart legend

### DIFF
--- a/app/utils/highcharts/area-spline-chart.js
+++ b/app/utils/highcharts/area-spline-chart.js
@@ -13,12 +13,16 @@ export default class AreaSplineChart {
   }
 
   get highchartsOptions() {
-    const { chart, series } = this;
+    const { chart, isLegendEnabled, series } = this;
 
     return {
       chart: {
         backgroundColor: 'transparent',
         type: 'areaspline',
+      },
+
+      legend: {
+        enabled: isLegendEnabled,
       },
 
       series,
@@ -49,6 +53,12 @@ export default class AreaSplineChart {
         },
       },
     };
+  }
+
+  get isLegendEnabled() {
+    const { series } = this;
+
+    return series.length > 1;
   }
 
   get series() {

--- a/app/utils/highcharts/area-spline-chart.js
+++ b/app/utils/highcharts/area-spline-chart.js
@@ -1,10 +1,15 @@
 /*
   https://api.highcharts.com/highcharts/plotOptions.areaspline
 */
+import { tracked } from '@glimmer/tracking';
+
 export default class AreaSplineChart {
+  @tracked chart;
+  @tracked rawData;
+
   constructor({ chart, rawData }) {
     this.chart = chart;
-    this.series = createSeries(rawData);
+    this.rawData = rawData;
   }
 
   get highchartsOptions() {
@@ -45,9 +50,13 @@ export default class AreaSplineChart {
       },
     };
   }
+
+  get series() {
+    return createSeries(this.rawData);
+  }
 }
 
-export function createSeries(rawData = []) {
+function createSeries(rawData = []) {
   const data = [];
 
   rawData.forEach((datum) => {

--- a/app/utils/highcharts/horizontal-bar-chart.js
+++ b/app/utils/highcharts/horizontal-bar-chart.js
@@ -13,12 +13,16 @@ export default class HorizontalBarChart {
   }
 
   get highchartsOptions() {
-    const { chart, series } = this;
+    const { chart, isLegendEnabled, series } = this;
 
     return {
       chart: {
         backgroundColor: 'transparent',
         type: 'bar',
+      },
+
+      legend: {
+        enabled: isLegendEnabled,
       },
 
       series,
@@ -50,6 +54,12 @@ export default class HorizontalBarChart {
         },
       },
     };
+  }
+
+  get isLegendEnabled() {
+    const { series } = this;
+
+    return series.length > 1;
   }
 
   get series() {

--- a/app/utils/highcharts/horizontal-bar-chart.js
+++ b/app/utils/highcharts/horizontal-bar-chart.js
@@ -1,10 +1,15 @@
 /*
   https://api.highcharts.com/highcharts/plotOptions.bar
 */
+import { tracked } from '@glimmer/tracking';
+
 export default class HorizontalBarChart {
+  @tracked chart;
+  @tracked rawData;
+
   constructor({ chart, rawData }) {
     this.chart = chart;
-    this.series = createSeries(rawData);
+    this.rawData = rawData;
   }
 
   get highchartsOptions() {
@@ -46,9 +51,13 @@ export default class HorizontalBarChart {
       },
     };
   }
+
+  get series() {
+    return createSeries(this.rawData);
+  }
 }
 
-export function createSeries(rawData = []) {
+function createSeries(rawData = []) {
   const data = [];
 
   rawData.forEach((datum) => {

--- a/app/utils/highcharts/pie-chart.js
+++ b/app/utils/highcharts/pie-chart.js
@@ -1,10 +1,15 @@
 /*
   https://api.highcharts.com/highcharts/plotOptions.pie
 */
+import { tracked } from '@glimmer/tracking';
+
 export default class PieChart {
+  @tracked chart;
+  @tracked rawData;
+
   constructor({ chart, rawData }) {
     this.chart = chart;
-    this.series = createSeries(rawData);
+    this.rawData = rawData;
   }
 
   get highchartsOptions() {
@@ -31,9 +36,13 @@ export default class PieChart {
       },
     };
   }
+
+  get series() {
+    return createSeries(this.rawData);
+  }
 }
 
-export function createSeries(rawData = []) {
+function createSeries(rawData = []) {
   const colors = [];
   const data = [];
 

--- a/app/utils/highcharts/spline-chart.js
+++ b/app/utils/highcharts/spline-chart.js
@@ -13,12 +13,16 @@ export default class SplineChart {
   }
 
   get highchartsOptions() {
-    const { chart, series } = this;
+    const { chart, isLegendEnabled, series } = this;
 
     return {
       chart: {
         backgroundColor: 'transparent',
         type: 'spline',
+      },
+
+      legend: {
+        enabled: isLegendEnabled,
       },
 
       plotOptions: {
@@ -58,6 +62,12 @@ export default class SplineChart {
         },
       },
     };
+  }
+
+  get isLegendEnabled() {
+    const { series } = this;
+
+    return series.length > 1;
   }
 
   get series() {

--- a/app/utils/highcharts/spline-chart.js
+++ b/app/utils/highcharts/spline-chart.js
@@ -1,10 +1,15 @@
 /*
   https://api.highcharts.com/highcharts/plotOptions.spline
 */
+import { tracked } from '@glimmer/tracking';
+
 export default class SplineChart {
+  @tracked chart;
+  @tracked rawData;
+
   constructor({ chart, rawData }) {
     this.chart = chart;
-    this.series = createSeries(rawData);
+    this.rawData = rawData;
   }
 
   get highchartsOptions() {
@@ -54,9 +59,13 @@ export default class SplineChart {
       },
     };
   }
+
+  get series() {
+    return createSeries(this.rawData);
+  }
 }
 
-export function createSeries(rawData = []) {
+function createSeries(rawData = []) {
   const data = [];
 
   rawData.forEach((datum) => {

--- a/app/utils/highcharts/vertical-bar-chart.js
+++ b/app/utils/highcharts/vertical-bar-chart.js
@@ -1,10 +1,15 @@
 /*
   https://api.highcharts.com/highcharts/plotOptions.column
 */
+import { tracked } from '@glimmer/tracking';
+
 export default class VerticalBarChart {
+  @tracked chart;
+  @tracked rawData;
+
   constructor({ chart, rawData }) {
     this.chart = chart;
-    this.series = createSeries(rawData);
+    this.rawData = rawData;
   }
 
   get highchartsOptions() {
@@ -45,9 +50,13 @@ export default class VerticalBarChart {
       },
     };
   }
+
+  get series() {
+    return createSeries(this.rawData);
+  }
 }
 
-export function createSeries(rawData = []) {
+function createSeries(rawData = []) {
   const data = [];
 
   rawData.forEach((datum) => {

--- a/app/utils/highcharts/vertical-bar-chart.js
+++ b/app/utils/highcharts/vertical-bar-chart.js
@@ -13,12 +13,16 @@ export default class VerticalBarChart {
   }
 
   get highchartsOptions() {
-    const { chart, series } = this;
+    const { chart, isLegendEnabled, series } = this;
 
     return {
       chart: {
         backgroundColor: 'transparent',
         type: 'column',
+      },
+
+      legend: {
+        enabled: isLegendEnabled,
       },
 
       series,
@@ -49,6 +53,12 @@ export default class VerticalBarChart {
         },
       },
     };
+  }
+
+  get isLegendEnabled() {
+    const { series } = this;
+
+    return series.length > 1;
   }
 
   get series() {

--- a/tests/unit/utils/highcharts/area-spline-chart-test.js
+++ b/tests/unit/utils/highcharts/area-spline-chart-test.js
@@ -42,6 +42,9 @@ module('Unit | Utility | highcharts/area-spline-chart', function (hooks) {
         rawData: this.rawData,
       });
 
+      // We tested `legend` in a separate module
+      delete highchartsOptions.legend;
+
       // We tested `series` in a separate module
       delete highchartsOptions.series;
 
@@ -88,6 +91,41 @@ module('Unit | Utility | highcharts/area-spline-chart', function (hooks) {
         },
         'We get the correct value.'
       );
+    });
+  });
+
+  module('isLegendEnabled', function () {
+    test('returns true when series has more than 1 element', function (assert) {
+      const rawData = this.rawData;
+
+      const { isLegendEnabled } = new AreaSplineChart({
+        chart: this.chart,
+        rawData,
+      });
+
+      assert.true(isLegendEnabled, 'We get the correct value.');
+    });
+
+    test('returns false when series has 1 element', function (assert) {
+      const rawData = [this.rawData[0]];
+
+      const { isLegendEnabled } = new AreaSplineChart({
+        chart: this.chart,
+        rawData,
+      });
+
+      assert.false(isLegendEnabled, 'We get the correct value.');
+    });
+
+    test('returns false when series has 0 elements', function (assert) {
+      const rawData = [];
+
+      const { isLegendEnabled } = new AreaSplineChart({
+        chart: this.chart,
+        rawData,
+      });
+
+      assert.false(isLegendEnabled, 'We get the correct value.');
     });
   });
 

--- a/tests/unit/utils/highcharts/area-spline-chart-test.js
+++ b/tests/unit/utils/highcharts/area-spline-chart-test.js
@@ -3,50 +3,48 @@ import AreaSplineChart, {
 } from 'ember-website/utils/highcharts/area-spline-chart';
 import { module, test } from 'qunit';
 
-module('Unit | Utility | highcharts/area-spline-chart', function () {
-  module('AreaSplineChart', function () {
-    test('highchartsOptions returns an object that is compatible with Highcharts', function (assert) {
-      const { highchartsOptions } = new AreaSplineChart({
-        chart: {
-          categories: [
-            '1.x',
-            '2.x',
-            '3.0-3.4',
-            '3.5-3.8',
-            '3.9-3.12',
-            '3.13-3.16',
-          ],
-          subtitle: '(Multi-select question)',
-          title: 'Which version(s) of Ember are in use in your apps?',
-        },
+module('Unit | Utility | highcharts/area-spline-chart', function (hooks) {
+  hooks.beforeEach(function () {
+    this.chart = {
+      categories: ['1.x', '2.x', '3.0-3.4', '3.5-3.8', '3.9-3.12', '3.13-3.16'],
+      subtitle: '(Multi-select question)',
+      title: 'Which version(s) of Ember are in use in your apps?',
+    };
 
-        rawData: [
-          {
-            color: '#1E719B',
-            label: '2019',
-            values: [
-              100 * (79 / 1232), // 1.x
-              100 * (443 / 1232), // 2.x
-              100 * (488 / 1232), // 3.0 - 3.4
-              100 * (675 / 1232), // 3.5 - 3.8
-            ],
-          },
-          {
-            color: '#9B2918',
-            label: '2020',
-            values: [
-              100 * (27 / 1006), // 1.x
-              100 * (111 / 1006), // 2.x
-              100 * (121 / 1006), // 3.0 - 3.4
-              100 * (148 / 1006), // 3.5 - 3.8
-              100 * (291 / 1006), // 3.9 - 3.12
-              100 * (524 / 1006), // 3.13 - 3.16
-            ],
-          },
+    this.rawData = [
+      {
+        color: '#1E719B',
+        label: '2019',
+        values: [
+          100 * (79 / 1232), // 1.x
+          100 * (443 / 1232), // 2.x
+          100 * (488 / 1232), // 3.0 - 3.4
+          100 * (675 / 1232), // 3.5 - 3.8
         ],
+      },
+      {
+        color: '#9B2918',
+        label: '2020',
+        values: [
+          100 * (27 / 1006), // 1.x
+          100 * (111 / 1006), // 2.x
+          100 * (121 / 1006), // 3.0 - 3.4
+          100 * (148 / 1006), // 3.5 - 3.8
+          100 * (291 / 1006), // 3.9 - 3.12
+          100 * (524 / 1006), // 3.13 - 3.16
+        ],
+      },
+    ];
+  });
+
+  module('highchartsOptions', function () {
+    test('returns a configuration object that is compatible with Highcharts', function (assert) {
+      const { highchartsOptions } = new AreaSplineChart({
+        chart: this.chart,
+        rawData: this.rawData,
       });
 
-      // series has been tested through the createSeries test module
+      // We tested `series` in a separate module
       delete highchartsOptions.series;
 
       assert.deepEqual(
@@ -96,33 +94,8 @@ module('Unit | Utility | highcharts/area-spline-chart', function () {
   });
 
   module('createSeries', function () {
-    test('returns the series object', function (assert) {
-      const rawData = [
-        {
-          color: '#1E719B',
-          label: '2019',
-          values: [
-            100 * (79 / 1232),
-            100 * (443 / 1232),
-            100 * (488 / 1232),
-            100 * (675 / 1232),
-          ],
-        },
-        {
-          color: '#9B2918',
-          label: '2020',
-          values: [
-            100 * (27 / 1006),
-            100 * (111 / 1006),
-            100 * (121 / 1006),
-            100 * (148 / 1006),
-            100 * (291 / 1006),
-            100 * (524 / 1006),
-          ],
-        },
-      ];
-
-      const series = createSeries(rawData);
+    test('transforms rawData into an array that is compatible with Highcharts', function (assert) {
+      const series = createSeries(this.rawData);
 
       assert.strictEqual(series.length, 2, 'We see 2 series of data.');
 

--- a/tests/unit/utils/highcharts/area-spline-chart-test.js
+++ b/tests/unit/utils/highcharts/area-spline-chart-test.js
@@ -1,6 +1,4 @@
-import AreaSplineChart, {
-  createSeries,
-} from 'ember-website/utils/highcharts/area-spline-chart';
+import AreaSplineChart from 'ember-website/utils/highcharts/area-spline-chart';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | highcharts/area-spline-chart', function (hooks) {
@@ -93,9 +91,12 @@ module('Unit | Utility | highcharts/area-spline-chart', function (hooks) {
     });
   });
 
-  module('createSeries', function () {
+  module('series', function () {
     test('transforms rawData into an array that is compatible with Highcharts', function (assert) {
-      const series = createSeries(this.rawData);
+      const { series } = new AreaSplineChart({
+        chart: this.chart,
+        rawData: this.rawData,
+      });
 
       assert.strictEqual(series.length, 2, 'We see 2 series of data.');
 

--- a/tests/unit/utils/highcharts/horizontal-bar-chart-test.js
+++ b/tests/unit/utils/highcharts/horizontal-bar-chart-test.js
@@ -3,38 +3,43 @@ import HorizontalBarChart, {
 } from 'ember-website/utils/highcharts/horizontal-bar-chart';
 import { module, test } from 'qunit';
 
-module('Unit | Utility | highcharts/horizontal-bar-chart', function () {
-  module('HorizontalBarChart', function () {
-    test('highchartsOptions returns an object that is compatible with Highcharts', function (assert) {
-      const { highchartsOptions } = new HorizontalBarChart({
-        chart: {
-          categories: [
-            'Writing RFCs',
-            'Commenting on RFCs',
-            'Reading RFCs',
-            'Opening PRs',
-            'Stack Overflow',
-            'emberjs.com blog',
-          ],
-          subtitle: 'Movers and Shakers from Last Year',
-          title: 'How do you stay up to date with Ember?',
-        },
+module('Unit | Utility | highcharts/horizontal-bar-chart', function (hooks) {
+  hooks.beforeEach(function () {
+    this.chart = {
+      categories: [
+        'Writing RFCs',
+        'Commenting on RFCs',
+        'Reading RFCs',
+        'Opening PRs',
+        'Stack Overflow',
+        'emberjs.com blog',
+      ],
+      subtitle: 'Movers and Shakers from Last Year',
+      title: 'How do you stay up to date with Ember?',
+    };
 
-        rawData: [
-          {
-            color: '#4B4B4B',
-            label: '2017',
-            values: [1.9, 5.2, 33.3, 16.4, 41.6, 49.8],
-          },
-          {
-            color: '#F23818',
-            label: '2018',
-            values: [3.0, 9.8, 52.2, 23.8, 34.2, 57.8],
-          },
-        ],
+    this.rawData = [
+      {
+        color: '#4B4B4B',
+        label: '2017',
+        values: [1.9, 5.2, 33.3, 16.4, 41.6, 49.8],
+      },
+      {
+        color: '#F23818',
+        label: '2018',
+        values: [3.0, 9.8, 52.2, 23.8, 34.2, 57.8],
+      },
+    ];
+  });
+
+  module('highchartsOptions', function () {
+    test('returns a configuration object that is compatible with Highcharts', function (assert) {
+      const { highchartsOptions } = new HorizontalBarChart({
+        chart: this.chart,
+        rawData: this.rawData,
       });
 
-      // series has been tested through the createSeries test module
+      // We tested `series` in a separate module
       delete highchartsOptions.series;
 
       assert.deepEqual(
@@ -85,21 +90,8 @@ module('Unit | Utility | highcharts/horizontal-bar-chart', function () {
   });
 
   module('createSeries', function () {
-    test('returns the series object', function (assert) {
-      const rawData = [
-        {
-          color: '#4B4B4B',
-          label: '2017',
-          values: [1.9, 5.2, 33.3, 16.4, 41.6, 49.8],
-        },
-        {
-          color: '#F23818',
-          label: '2018',
-          values: [3.0, 9.8, 52.2, 23.8, 34.2, 57.8],
-        },
-      ];
-
-      const series = createSeries(rawData);
+    test('transforms rawData into an array that is compatible with Highcharts', function (assert) {
+      const series = createSeries(this.rawData);
 
       assert.strictEqual(series.length, 2, 'We see 2 series of data.');
 

--- a/tests/unit/utils/highcharts/horizontal-bar-chart-test.js
+++ b/tests/unit/utils/highcharts/horizontal-bar-chart-test.js
@@ -1,6 +1,4 @@
-import HorizontalBarChart, {
-  createSeries,
-} from 'ember-website/utils/highcharts/horizontal-bar-chart';
+import HorizontalBarChart from 'ember-website/utils/highcharts/horizontal-bar-chart';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | highcharts/horizontal-bar-chart', function (hooks) {
@@ -89,9 +87,12 @@ module('Unit | Utility | highcharts/horizontal-bar-chart', function (hooks) {
     });
   });
 
-  module('createSeries', function () {
+  module('series', function () {
     test('transforms rawData into an array that is compatible with Highcharts', function (assert) {
-      const series = createSeries(this.rawData);
+      const { series } = new HorizontalBarChart({
+        chart: this.chart,
+        rawData: this.rawData,
+      });
 
       assert.strictEqual(series.length, 2, 'We see 2 series of data.');
 

--- a/tests/unit/utils/highcharts/horizontal-bar-chart-test.js
+++ b/tests/unit/utils/highcharts/horizontal-bar-chart-test.js
@@ -37,6 +37,9 @@ module('Unit | Utility | highcharts/horizontal-bar-chart', function (hooks) {
         rawData: this.rawData,
       });
 
+      // We tested `legend` in a separate module
+      delete highchartsOptions.legend;
+
       // We tested `series` in a separate module
       delete highchartsOptions.series;
 
@@ -84,6 +87,41 @@ module('Unit | Utility | highcharts/horizontal-bar-chart', function (hooks) {
         },
         'We get the correct value.'
       );
+    });
+  });
+
+  module('isLegendEnabled', function () {
+    test('returns true when series has more than 1 element', function (assert) {
+      const rawData = this.rawData;
+
+      const { isLegendEnabled } = new HorizontalBarChart({
+        chart: this.chart,
+        rawData,
+      });
+
+      assert.true(isLegendEnabled, 'We get the correct value.');
+    });
+
+    test('returns false when series has 1 element', function (assert) {
+      const rawData = [this.rawData[0]];
+
+      const { isLegendEnabled } = new HorizontalBarChart({
+        chart: this.chart,
+        rawData,
+      });
+
+      assert.false(isLegendEnabled, 'We get the correct value.');
+    });
+
+    test('returns false when series has 0 elements', function (assert) {
+      const rawData = [];
+
+      const { isLegendEnabled } = new HorizontalBarChart({
+        chart: this.chart,
+        rawData,
+      });
+
+      assert.false(isLegendEnabled, 'We get the correct value.');
     });
   });
 

--- a/tests/unit/utils/highcharts/pie-chart-test.js
+++ b/tests/unit/utils/highcharts/pie-chart-test.js
@@ -1,6 +1,4 @@
-import PieChart, {
-  createSeries,
-} from 'ember-website/utils/highcharts/pie-chart';
+import PieChart from 'ember-website/utils/highcharts/pie-chart';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | highcharts/pie-chart', function (hooks) {
@@ -50,9 +48,12 @@ module('Unit | Utility | highcharts/pie-chart', function (hooks) {
     });
   });
 
-  module('createSeries', function () {
+  module('series', function () {
     test('transforms rawData into an array that is compatible with Highcharts', function (assert) {
-      const series = createSeries(this.rawData);
+      const { series } = new PieChart({
+        chart: this.chart,
+        rawData: this.rawData,
+      });
 
       assert.strictEqual(series.length, 1, 'We see 1 series of data.');
 

--- a/tests/unit/utils/highcharts/pie-chart-test.js
+++ b/tests/unit/utils/highcharts/pie-chart-test.js
@@ -3,21 +3,26 @@ import PieChart, {
 } from 'ember-website/utils/highcharts/pie-chart';
 import { module, test } from 'qunit';
 
-module('Unit | Utility | highcharts/pie-chart', function () {
-  module('PieChart', function () {
-    test('highchartsOptions returns an object that is compatible with Highcharts', function (assert) {
-      const { highchartsOptions } = new PieChart({
-        chart: {
-          title: 'Do you internationalize your applications?',
-        },
+module('Unit | Utility | highcharts/pie-chart', function (hooks) {
+  hooks.beforeEach(function () {
+    this.chart = {
+      title: 'Do you internationalize your applications?',
+    };
 
-        rawData: [
-          { color: '#1E719B', label: 'Yes', value: 480 },
-          { color: '#E04E39', label: 'No', value: 267 },
-        ],
+    this.rawData = [
+      { color: '#1E719B', label: 'Yes', value: 480 },
+      { color: '#E04E39', label: 'No', value: 267 },
+    ];
+  });
+
+  module('highchartsOptions', function () {
+    test('returns a configuration object that is compatible with Highcharts', function (assert) {
+      const { highchartsOptions } = new PieChart({
+        chart: this.chart,
+        rawData: this.rawData,
       });
 
-      // series has been tested through the createSeries test module
+      // We tested `series` in a separate module
       delete highchartsOptions.series;
 
       assert.deepEqual(
@@ -46,13 +51,8 @@ module('Unit | Utility | highcharts/pie-chart', function () {
   });
 
   module('createSeries', function () {
-    test('returns the series object', function (assert) {
-      const rawData = [
-        { color: '#1E719B', label: 'Yes', value: 480 },
-        { color: '#E04E39', label: 'No', value: 267 },
-      ];
-
-      const series = createSeries(rawData);
+    test('transforms rawData into an array that is compatible with Highcharts', function (assert) {
+      const series = createSeries(this.rawData);
 
       assert.strictEqual(series.length, 1, 'We see 1 series of data.');
 

--- a/tests/unit/utils/highcharts/spline-chart-test.js
+++ b/tests/unit/utils/highcharts/spline-chart-test.js
@@ -1,6 +1,4 @@
-import SplineChart, {
-  createSeries,
-} from 'ember-website/utils/highcharts/spline-chart';
+import SplineChart from 'ember-website/utils/highcharts/spline-chart';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | highcharts/spline-chart', function (hooks) {
@@ -127,9 +125,12 @@ module('Unit | Utility | highcharts/spline-chart', function (hooks) {
     });
   });
 
-  module('createSeries', function () {
+  module('series', function () {
     test('transforms rawData into an array that is compatible with Highcharts', function (assert) {
-      const series = createSeries(this.rawData);
+      const { series } = new SplineChart({
+        chart: this.chart,
+        rawData: this.rawData,
+      });
 
       assert.strictEqual(series.length, 2, 'We see 2 series of data.');
 

--- a/tests/unit/utils/highcharts/spline-chart-test.js
+++ b/tests/unit/utils/highcharts/spline-chart-test.js
@@ -59,6 +59,9 @@ module('Unit | Utility | highcharts/spline-chart', function (hooks) {
         rawData: this.rawData,
       });
 
+      // We tested `legend` in a separate module
+      delete highchartsOptions.legend;
+
       // We tested `series` in a separate module
       delete highchartsOptions.series;
 
@@ -122,6 +125,41 @@ module('Unit | Utility | highcharts/spline-chart', function (hooks) {
         },
         'We get the correct value.'
       );
+    });
+  });
+
+  module('isLegendEnabled', function () {
+    test('returns true when series has more than 1 element', function (assert) {
+      const rawData = this.rawData;
+
+      const { isLegendEnabled } = new SplineChart({
+        chart: this.chart,
+        rawData,
+      });
+
+      assert.true(isLegendEnabled, 'We get the correct value.');
+    });
+
+    test('returns false when series has 1 element', function (assert) {
+      const rawData = [this.rawData[0]];
+
+      const { isLegendEnabled } = new SplineChart({
+        chart: this.chart,
+        rawData,
+      });
+
+      assert.false(isLegendEnabled, 'We get the correct value.');
+    });
+
+    test('returns false when series has 0 elements', function (assert) {
+      const rawData = [];
+
+      const { isLegendEnabled } = new SplineChart({
+        chart: this.chart,
+        rawData,
+      });
+
+      assert.false(isLegendEnabled, 'We get the correct value.');
     });
   });
 

--- a/tests/unit/utils/highcharts/spline-chart-test.js
+++ b/tests/unit/utils/highcharts/spline-chart-test.js
@@ -3,62 +3,65 @@ import SplineChart, {
 } from 'ember-website/utils/highcharts/spline-chart';
 import { module, test } from 'qunit';
 
-module('Unit | Utility | highcharts/spline-chart', function () {
-  module('SplineChart', function () {
-    test('highchartsOptions returns an object that is compatible with Highcharts', function (assert) {
-      const { highchartsOptions } = new SplineChart({
-        chart: {
-          categories: [
-            '1.13',
-            '2.0',
-            '2.1',
-            '2.2',
-            '2.3',
-            '2.4',
-            '2.5',
-            '2.6',
-            '2.7',
-            '2.8',
-            '2.9',
-            '2.10',
-            '2.11',
-            '2.12',
-          ],
-          title: 'Which versions of Ember Data are used in your apps?',
-        },
+module('Unit | Utility | highcharts/spline-chart', function (hooks) {
+  hooks.beforeEach(function () {
+    this.chart = {
+      categories: [
+        '1.13',
+        '2.0',
+        '2.1',
+        '2.2',
+        '2.3',
+        '2.4',
+        '2.5',
+        '2.6',
+        '2.7',
+        '2.8',
+        '2.9',
+        '2.10',
+        '2.11',
+        '2.12',
+      ],
+      title: 'Which versions of Ember Data are used in your apps?',
+    };
 
-        rawData: [
-          {
-            color: '#4b4b4b',
-            label: '2016',
-            values: [
-              27,
-              6,
-              4,
-              8,
-              21,
-              42,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-            ],
-          },
-          {
-            color: '#f23818',
-            label: '2017',
-            values: [
-              9, 2.15, 2.1, 1.5, 2.8, 7, 3, 4, 4, 13.8, 7, 21.6, 34.9, 17,
-            ],
-          },
+    this.rawData = [
+      {
+        color: '#4b4b4b',
+        label: '2016',
+        values: [
+          27,
+          6,
+          4,
+          8,
+          21,
+          42,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
         ],
+      },
+      {
+        color: '#f23818',
+        label: '2017',
+        values: [9, 2.15, 2.1, 1.5, 2.8, 7, 3, 4, 4, 13.8, 7, 21.6, 34.9, 17],
+      },
+    ];
+  });
+
+  module('highchartsOptions', function () {
+    test('returns a configuration object that is compatible with Highcharts', function (assert) {
+      const { highchartsOptions } = new SplineChart({
+        chart: this.chart,
+        rawData: this.rawData,
       });
 
-      // series has been tested through the createSeries test module
+      // We tested `series` in a separate module
       delete highchartsOptions.series;
 
       assert.deepEqual(
@@ -125,36 +128,8 @@ module('Unit | Utility | highcharts/spline-chart', function () {
   });
 
   module('createSeries', function () {
-    test('returns the series object', function (assert) {
-      const rawData = [
-        {
-          color: '#4b4b4b',
-          label: '2016',
-          values: [
-            27,
-            6,
-            4,
-            8,
-            21,
-            42,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-          ],
-        },
-        {
-          color: '#f23818',
-          label: '2017',
-          values: [9, 2.15, 2.1, 1.5, 2.8, 7, 3, 4, 4, 13.8, 7, 21.6, 34.9, 17],
-        },
-      ];
-
-      const series = createSeries(rawData);
+    test('transforms rawData into an array that is compatible with Highcharts', function (assert) {
+      const series = createSeries(this.rawData);
 
       assert.strictEqual(series.length, 2, 'We see 2 series of data.');
 

--- a/tests/unit/utils/highcharts/vertical-bar-chart-test.js
+++ b/tests/unit/utils/highcharts/vertical-bar-chart-test.js
@@ -1,6 +1,4 @@
-import VerticalBarChart, {
-  createSeries,
-} from 'ember-website/utils/highcharts/vertical-bar-chart';
+import VerticalBarChart from 'ember-website/utils/highcharts/vertical-bar-chart';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | highcharts/vertical-bar-chart', function (hooks) {
@@ -83,9 +81,12 @@ module('Unit | Utility | highcharts/vertical-bar-chart', function (hooks) {
     });
   });
 
-  module('createSeries', function () {
+  module('series', function () {
     test('transforms rawData into an array that is compatible with Highcharts', function (assert) {
-      const series = createSeries(this.rawData);
+      const { series } = new VerticalBarChart({
+        chart: this.chart,
+        rawData: this.rawData,
+      });
 
       assert.strictEqual(series.length, 4, 'We see 4 series of data.');
 

--- a/tests/unit/utils/highcharts/vertical-bar-chart-test.js
+++ b/tests/unit/utils/highcharts/vertical-bar-chart-test.js
@@ -39,6 +39,9 @@ module('Unit | Utility | highcharts/vertical-bar-chart', function (hooks) {
         rawData: this.rawData,
       });
 
+      // We tested `legend` in a separate module
+      delete highchartsOptions.legend;
+
       // We tested `series` in a separate module
       delete highchartsOptions.series;
 
@@ -78,6 +81,41 @@ module('Unit | Utility | highcharts/vertical-bar-chart', function (hooks) {
         },
         'We get the correct value.'
       );
+    });
+  });
+
+  module('isLegendEnabled', function () {
+    test('returns true when series has more than 1 element', function (assert) {
+      const rawData = this.rawData;
+
+      const { isLegendEnabled } = new VerticalBarChart({
+        chart: this.chart,
+        rawData,
+      });
+
+      assert.true(isLegendEnabled, 'We get the correct value.');
+    });
+
+    test('returns false when series has 1 element', function (assert) {
+      const rawData = [this.rawData[0]];
+
+      const { isLegendEnabled } = new VerticalBarChart({
+        chart: this.chart,
+        rawData,
+      });
+
+      assert.false(isLegendEnabled, 'We get the correct value.');
+    });
+
+    test('returns false when series has 0 elements', function (assert) {
+      const rawData = [];
+
+      const { isLegendEnabled } = new VerticalBarChart({
+        chart: this.chart,
+        rawData,
+      });
+
+      assert.false(isLegendEnabled, 'We get the correct value.');
     });
   });
 

--- a/tests/unit/utils/highcharts/vertical-bar-chart-test.js
+++ b/tests/unit/utils/highcharts/vertical-bar-chart-test.js
@@ -3,40 +3,45 @@ import VerticalBarChart, {
 } from 'ember-website/utils/highcharts/vertical-bar-chart';
 import { module, test } from 'qunit';
 
-module('Unit | Utility | highcharts/vertical-bar-chart', function () {
-  module('VerticalBarChart', function () {
-    test('highchartsOptions returns an object that is compatible with Highcharts', function (assert) {
-      const { highchartsOptions } = new VerticalBarChart({
-        chart: {
-          categories: ['Beginner', 'Intermediate', 'Advanced'],
-          title: 'Rank your web skills',
-        },
+module('Unit | Utility | highcharts/vertical-bar-chart', function (hooks) {
+  hooks.beforeEach(function () {
+    this.chart = {
+      categories: ['Beginner', 'Intermediate', 'Advanced'],
+      title: 'Rank your web skills',
+    };
 
-        rawData: [
-          {
-            color: '#1A5E9A',
-            label: 'ARIA',
-            values: [68.3, 25.7, 6],
-          },
-          {
-            color: '#32AADE',
-            label: 'CSS',
-            values: [9.6, 47.0, 43.4],
-          },
-          {
-            color: '#F2682A',
-            label: 'HTML',
-            values: [1.9, 36.0, 62.1],
-          },
-          {
-            color: '#F1BF28',
-            label: 'JavaScript',
-            values: [2.7, 35.9, 61.4],
-          },
-        ],
+    this.rawData = [
+      {
+        color: '#1A5E9A',
+        label: 'ARIA',
+        values: [68.3, 25.7, 6],
+      },
+      {
+        color: '#32AADE',
+        label: 'CSS',
+        values: [9.6, 47.0, 43.4],
+      },
+      {
+        color: '#F2682A',
+        label: 'HTML',
+        values: [1.9, 36.0, 62.1],
+      },
+      {
+        color: '#F1BF28',
+        label: 'JavaScript',
+        values: [2.7, 35.9, 61.4],
+      },
+    ];
+  });
+
+  module('highchartsOptions', function () {
+    test('returns a configuration object that is compatible with Highcharts', function (assert) {
+      const { highchartsOptions } = new VerticalBarChart({
+        chart: this.chart,
+        rawData: this.rawData,
       });
 
-      // series has been tested through the createSeries test module
+      // We tested `series` in a separate module
       delete highchartsOptions.series;
 
       assert.deepEqual(
@@ -79,31 +84,8 @@ module('Unit | Utility | highcharts/vertical-bar-chart', function () {
   });
 
   module('createSeries', function () {
-    test('returns the series object', function (assert) {
-      const rawData = [
-        {
-          color: '#1A5E9A',
-          label: 'ARIA',
-          values: [68.3, 25.7, 6],
-        },
-        {
-          color: '#32AADE',
-          label: 'CSS',
-          values: [9.6, 47.0, 43.4],
-        },
-        {
-          color: '#F2682A',
-          label: 'HTML',
-          values: [1.9, 36.0, 62.1],
-        },
-        {
-          color: '#F1BF28',
-          label: 'JavaScript',
-          values: [2.7, 35.9, 61.4],
-        },
-      ];
-
-      const series = createSeries(rawData);
+    test('transforms rawData into an array that is compatible with Highcharts', function (assert) {
+      const series = createSeries(this.rawData);
 
       assert.strictEqual(series.length, 4, 'We see 4 series of data.');
 


### PR DESCRIPTION
## Description

A feature was requested in #934. Namely, when a chart doesn't have multiple series, we hide the legend because the context is assumed to be clear.

I updated the utility files so that the feature will apply to all survey charts from 2015 to 2022.


## How to Review

The pull request can be divided into 3 parts. It may help to toggle the `Hide whitespace` option on GitHub.

- Commits 1-5: Used the `beforeEach` hook to use a common set of data across tests. Updated test descriptions and comments so that they may make more sense to a new contributor.
- Commits 6-10: Declared `chart` and `rawData` as tracked properties so that Ember can recompute values that depend on these properties.
- Commits 11-14: Allowed charts to hide legend when `series` has 0 or 1 element(s). (The `legend` key does not apply to pie charts in Highcharts.)


## Screenshots

Before:

<img width="1440" alt="The vertical bar chart shows a legend" src="https://user-images.githubusercontent.com/16869656/164703119-fc6e9c6a-30e0-43ac-9760-17d73f6a8ec1.png">

After:

<img width="1440" alt="The vertical bar chart doesn't show a legend anymore" src="https://user-images.githubusercontent.com/16869656/164703131-33eac93b-2da2-41d3-b1e5-cb776b463572.png">

