### PR TITLE
Update release pages for 4.3.0

### DIFF
--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -5,14 +5,14 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 4.0.0 # Manually update, the prior version to the current beta. See https://libraries.io/npm/ember-source throughout
-lastRelease: 4.1.0-beta.1 # Manually update
-futureVersion: 4.1.0-beta.2 # Manually update
-finalVersion: 4.1.0 # Manually update
+initialVersion: 4.3.0 # Manually update, the prior version to the current beta. See https://libraries.io/npm/ember-source throughout
+lastRelease: 4.4.0-beta.1 # Manually update
+futureVersion: 4.4.0-beta.2 # Manually update
+finalVersion: 4.4.0 # Manually update
 channel: beta
-cycleEstimatedFinishDate: 2022-01-24 12:00:00 # Manually update, the expected date of the finalVersion release
-date: 2021-11-20 # Manually update, get date for `initialVersion`
-nextDate: 2021-12-27 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+cycleEstimatedFinishDate: 2022-05-05 12:00:00 # Manually update, the expected date of the finalVersion release
+date: 2022-03-21 # Manually update, get date for `initialVersion`
+nextDate: 2022-05-05 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 4.1.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-initialReleaseDate: 2021-12-28 # Manually update
-lastRelease: 4.1.0 # Manually update
-futureVersion: 4.2.0 # Manually update
+initialVersion: 4.3.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+initialReleaseDate: 2022-03-21 # Manually update
+lastRelease: 4.3.0 # Manually update
+futureVersion: 4.4.0 # Manually update
 channel: release
-date: 2022-01-03 # Manually update, is today's date
+date: 2022-03-21 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -4,11 +4,11 @@ baseFileName: ember-data
 filter:
  - /ember-data\./
 repo: emberjs/data
-lastRelease: 4.2.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-futureVersion: 4.2.0-beta.1 # Manually update
-finalVersion: 4.2.0 # Manually update
+lastRelease: 4.3.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+futureVersion: 4.3.0-beta.1 # Manually update
+finalVersion: 4.3.0 # Manually update
 channel: beta
-date: 2021-12-31 # Manually update, get date for `lastRelease` 
+date: 2022-02-26 # Manually update, get date for `lastRelease` 
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ignoreFiles:

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -4,12 +4,12 @@ baseFileName: ember-data
 filter:
   - /ember-data\./
 repo: emberjs/data
-initialVersion: 4.1.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-initialReleaseDate: 2021-12-31 # Manually update, get date for `initialVersion`
-lastRelease: 4.1.0 # Manually update
-futureVersion: 4.1.1 # Manually update
+initialVersion: 4.3.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+initialReleaseDate: 2022-03-25 # Manually update, get date for `initialVersion`
+lastRelease: 4.3.0 # Manually update
+futureVersion: 4.3.0 # Manually update
 channel: release
-date: 2022-01-03 # Manually update, is today's date
+date: 2022-03-25 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ---


### PR DESCRIPTION
I used dates from the libraries.io links, but I wasn't sure about the relationship with `cycleEstimatedFinishDate` and `nextDate`

Also Ember Data doesn't have a 4.4.0-beta release, is it correct to leave at the last 4.3.0-beta?

If this was done correctly for 4.3.0, I'll submit another PR for the pending 4.4.0 release.
