### PR TITLE
remove emberconf cta from homepage

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -27,8 +27,6 @@
   </div>
 </section>
 
-<CtaEmberconf />
-
 <section aria-labelledby="section-batteries-included" class="bg-light-muted">
   <div class="container layout">
     <div class="lg:col-4 lg:start-2 text-center">


### PR DESCRIPTION
submitting as per @wifelette's request

EmberConf was in april but the emberjs.com website still features a CTA for EmberConf on the homepage.

This PR remove the CTA from the homepage.