### PR TITLE
4.5 Release - Update some release dates/versions

### DIFF
--- a/app/controllers/releases/lts.js
+++ b/app/controllers/releases/lts.js
@@ -3,12 +3,12 @@ import Controller from '@ember/controller';
 export default class ReleasesLtsController extends Controller {
   currentlySupportedLTS = [
     {
-      version: '3.28',
-      promotionDate: new Date('December 20, 2021'),
+      version: '4.4',
+      promotionDate: new Date('July 13, 2022'),
     },
     {
-      version: '3.24',
-      promotionDate: new Date('February 25, 2021'),
+      version: '3.28',
+      promotionDate: new Date('December 20, 2021'),
     },
   ];
 }

--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -85,8 +85,12 @@
       <th>Last minor release date</th>
     </tr>
   </thead>
-
   <tbody>
+    <tr>
+      <td>3.24</td>
+      <td>3.24.6</td>
+      <td>November 2021</td>
+    </tr>
     <tr>
       <td>3.20</td>
       <td>3.20.3</td>

--- a/data/project/ember/beta.md
+++ b/data/project/ember/beta.md
@@ -5,14 +5,14 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 4.3.0 # Manually update, the prior version to the current beta. See https://libraries.io/npm/ember-source throughout
-lastRelease: 4.4.0-beta.1 # Manually update
-futureVersion: 4.4.0-beta.2 # Manually update
-finalVersion: 4.4.0 # Manually update
+initialVersion: 4.5.0 # Manually update, the prior version to the current beta. See https://libraries.io/npm/ember-source throughout
+lastRelease: 4.6.0-beta.1 # Manually update
+futureVersion: 4.6.0-beta.2 # Manually update
+finalVersion: 4.6.0 # Manually update
 channel: beta
-cycleEstimatedFinishDate: 2022-05-05 12:00:00 # Manually update, the expected date of the finalVersion release
-date: 2022-03-21 # Manually update, get date for `initialVersion`
-nextDate: 2022-05-05 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
+cycleEstimatedFinishDate: 2022-07-28 12:00:00 # Manually update, the expected date of the finalVersion release
+date: 2022-07-28 12:00:00 # Manually update, get date for `initialVersion`
+nextDate: 2022-07-28 12:00:00 # Manually update, change next one to 6 weeks from this date...regardless of delays in the release
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/lts.md
+++ b/data/project/ember/lts.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 3.28.0
-initialReleaseDate: 2021-08-10
-lastRelease: 3.28.8
-futureVersion: 3.28.9
+initialVersion: 4.4.0
+initialReleaseDate: 2022-05-27
+lastRelease: 4.4.0
+futureVersion: 4.4.1
 channel: lts
-date: 2021-12-02
+date: 2022-05-27
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -6,11 +6,11 @@ filter:
   - /ember-template-compiler/
 repo: emberjs/ember.js
 initialVersion: 4.5.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-initialReleaseDate: 2022-07-12 # Manually update
+initialReleaseDate: 2022-07-13 # Manually update
 lastRelease: 4.5.0 # Manually update
 futureVersion: 4.6.0 # Manually update
 channel: release
-date: 2022-07-12 # Manually update, is today's date
+date: 2022-07-13 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/ember/release.md
+++ b/data/project/ember/release.md
@@ -5,12 +5,12 @@ filter:
   - /ember\./
   - /ember-template-compiler/
 repo: emberjs/ember.js
-initialVersion: 4.3.0 # Manually update, see https://libraries.io/npm/ember-source throughout
-initialReleaseDate: 2022-03-21 # Manually update
-lastRelease: 4.3.0 # Manually update
-futureVersion: 4.4.0 # Manually update
+initialVersion: 4.5.0 # Manually update, see https://libraries.io/npm/ember-source throughout
+initialReleaseDate: 2022-07-12 # Manually update
+lastRelease: 4.5.0 # Manually update
+futureVersion: 4.6.0 # Manually update
 channel: release
-date: 2022-03-21 # Manually update, is today's date
+date: 2022-07-12 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .debug.js
 ignoreFiles:

--- a/data/project/emberData/beta.md
+++ b/data/project/emberData/beta.md
@@ -4,9 +4,9 @@ baseFileName: ember-data
 filter:
  - /ember-data\./
 repo: emberjs/data
-lastRelease: 4.3.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-futureVersion: 4.3.0-beta.1 # Manually update
-finalVersion: 4.3.0 # Manually update
+lastRelease: 4.4.0-beta.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+futureVersion: 4.5.0-beta.1 # Manually update
+finalVersion: 4.5.0 # Manually update
 channel: beta
 date: 2022-02-26 # Manually update, get date for `lastRelease` 
 changelogPath: CHANGELOG.md

--- a/data/project/emberData/release.md
+++ b/data/project/emberData/release.md
@@ -4,12 +4,12 @@ baseFileName: ember-data
 filter:
   - /ember-data\./
 repo: emberjs/data
-initialVersion: 4.3.0 # Manually update, see https://libraries.io/npm/ember-data throughout
-initialReleaseDate: 2022-03-25 # Manually update, get date for `initialVersion`
-lastRelease: 4.3.0 # Manually update
-futureVersion: 4.3.0 # Manually update
+initialVersion: 4.4.0 # Manually update, see https://libraries.io/npm/ember-data throughout
+initialReleaseDate: 2022-05-27 # Manually update, get date for `initialVersion`
+lastRelease: 4.4.0 # Manually update
+futureVersion: 4.5.0 # Manually update
 channel: release
-date: 2022-03-25 # Manually update, is today's date
+date: 2022-05-27 # Manually update, is today's date
 changelogPath: CHANGELOG.md
 debugFileName: .js
 ---


### PR DESCRIPTION
I don't think these are totally correct, but it's better than what we had.

I think we need to remove this specificity in the app and link to the release pages in GitHub, long term.