### PR TITLE
Update langugae about move from Slack to Discord

### DIFF
--- a/app/templates/community/index.hbs
+++ b/app/templates/community/index.hbs
@@ -11,7 +11,7 @@
       <a href="http://discuss.emberjs.com">Ember Discussion Forum</a> &mdash; a great venue for discussing features, architecture and best practices.
     </p>
     <p>
-      <a href="https://discord.gg/emberjs">Ember Community Discord</a> &mdash; ask questions and chat with community members in real-time. (Looking for the Ember Community Slack? We recently switched away from Slack to Discord. Read more about why in the respective <a href="https://emberjs.github.io/rfcs/0345-discord.html">Discord RFC</a>).
+      <a href="https://discord.gg/emberjs">Ember Community Discord</a> &mdash; ask questions and chat with community members in real-time. (Looking for the Ember Community Slack? We switched away from Slack to Discord back in 2018. Read more about why in the <a href="https://emberjs.github.io/rfcs/0345-discord.html">Discord RFC</a>).
     </p>
     <p>
       <a href="http://stackoverflow.com/questions/tagged/ember.js">StackOverflow</a> &mdash; used to track questions. Just

--- a/app/templates/community/index.hbs
+++ b/app/templates/community/index.hbs
@@ -11,7 +11,7 @@
       <a href="http://discuss.emberjs.com">Ember Discussion Forum</a> &mdash; a great venue for discussing features, architecture and best practices.
     </p>
     <p>
-      <a href="https://discord.gg/emberjs">Ember Community Discord</a> &mdash; ask questions and chat with community members in real-time. (Looking for the Ember Community Slack? We switched away from Slack to Discord back in 2018. Read more about why in the <a href="https://emberjs.github.io/rfcs/0345-discord.html">Discord RFC</a>).
+      <a href="https://discord.gg/emberjs">Ember Community Discord</a> &mdash; ask questions and chat with community members in real-time..
     </p>
     <p>
       <a href="http://stackoverflow.com/questions/tagged/ember.js">StackOverflow</a> &mdash; used to track questions. Just

--- a/app/templates/community/index.hbs
+++ b/app/templates/community/index.hbs
@@ -11,7 +11,7 @@
       <a href="http://discuss.emberjs.com">Ember Discussion Forum</a> &mdash; a great venue for discussing features, architecture and best practices.
     </p>
     <p>
-      <a href="https://discord.gg/emberjs">Ember Community Discord</a> &mdash; ask questions and chat with community members in real-time..
+      <a href="https://discord.gg/emberjs">Ember Community Discord</a> &mdash; ask questions and chat with community members in real-time.
     </p>
     <p>
       <a href="http://stackoverflow.com/questions/tagged/ember.js">StackOverflow</a> &mdash; used to track questions. Just


### PR DESCRIPTION
- Fall 2018 is no longer 'recently'!
- 'respective' is not quite the right word there, and isn't adding anything to the sentence, so drop it!

**Alternative:** it’s been four years. Do we still want this *at all*? I could also just delete this whole parenthetical!