### PR TITLE
Add Ember Fest videos to videos links

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -238,7 +238,7 @@
           <li><a href="https://www.youtube.com/watch?v=Cvz-9ccflKQ">Ember.js: The Documentary</a></li>
           <li><a href="https://embermap.com/">Ember Map</a></li>
           <li><a href="https://www.youtube.com/channel/UCMmzJ82sCmooDdtzVY8FxEA/videos">Ember Videos</a></li>
-          <li><a href="https://www.youtube.com/@emberfest/videos">Ember Fest Videos</a></li>
+          <li><a href="https://www.youtube.com/@emberfest/videos">EmberFest Videos</a></li>
         </ul>
       </EsCard>
     </ul>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -238,6 +238,7 @@
           <li><a href="https://www.youtube.com/watch?v=Cvz-9ccflKQ">Ember.js: The Documentary</a></li>
           <li><a href="https://embermap.com/">Ember Map</a></li>
           <li><a href="https://www.youtube.com/channel/UCMmzJ82sCmooDdtzVY8FxEA/videos">Ember Videos</a></li>
+          <li><a href="https://www.youtube.com/@emberfest/videos">Ember Fest Videos</a></li>
         </ul>
       </EsCard>
     </ul>


### PR DESCRIPTION
Adds a link to Ember Fest videos: https://www.youtube.com/@emberfest/videos

# 😇 After

![image](https://user-images.githubusercontent.com/4335166/209953019-420aefd0-ad35-4578-9fb4-ab062d80c5f1.png)
