### PR TITLE
Update some prose on releases overview page

### DIFF
--- a/app/templates/releases/index.hbs
+++ b/app/templates/releases/index.hbs
@@ -19,8 +19,9 @@
 </div>
 
 <p>
-  Read more about our
-  <LinkTo @route="releases.lts">Long Term Support</LinkTo>,
+  In addition to our latest release, we support a few other versions of Ember.
+  To see what other versions of Ember are supported, or to read more about each release type, see
+  <LinkTo @route="releases.lts">long-term support (LTS)</LinkTo>,
   <LinkTo @route="releases.release">latest stable</LinkTo>,
   <LinkTo @route="releases.beta">beta</LinkTo>,
   and <LinkTo @route="releases.canary">canary</LinkTo>


### PR DESCRIPTION
If merged, this PR tries to clarify some of the language used on the release overview page to show where folks can find different versions of Ember that are supported (without adding additional maintenance overhead).