### PR TITLE
update ember-asset-size-tracker

### DIFF
--- a/.github/workflows/ember-assets.yml
+++ b/.github/workflows/ember-assets.yml
@@ -4,13 +4,13 @@ on: [pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    permissions:
+      pull-requests: write
     steps:
-    - uses: actions/checkout@v2-beta
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0 
-    - uses: simplabs/ember-asset-size-action@v1
+    - uses: mainmatter/ember-asset-size-action@v3
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This brings it up to the latest and at also allows it to always post a comment even when the creator of the PR does not have merge permissions 👍 