### PR TITLE
Add /logos/ route new sections and anchor links

### DIFF
--- a/app/components/mascots/mascot-list.hbs
+++ b/app/components/mascots/mascot-list.hbs
@@ -1,6 +1,6 @@
 <ul class="unstyled grid {{if (eq @display "small") "sm:grid-2 lg:grid-3" "sm:grid-1 lg:grid-2"}}">
   {{#each @mascots as |mascot|}}
-    <li data-test-mascot>
+    <li id={{mascot.id}} data-test-mascot>
       <Mascots::MascotList::Item
         @mascot={{mascot}}
       />

--- a/app/templates/logos.hbs
+++ b/app/templates/logos.hbs
@@ -131,6 +131,43 @@
     <p>We sometimes grant licenses for specific use cases, and certain community initiatives may, with approval, commission the design of custom Tomsters and Zoeys via official channels. For more info on commissioned mascots, <LinkTo @route="mascots.faq">visit the Tomster FAQ page</LinkTo>.</p>
   </section>
 
+  <section aria-labelledby="company-technology-pages" class="branding-section">
+    <h2 id="company-technology-pages">Company Technology Pages</h2>
+    <p>Many companies choose to display icons and logos of their technology stack on their company About Us or Career pages. The <strong>Tomster Lockup, Classic Zoey</strong> and <strong>Primary Logo</strong> are approved for this use case. Specific permission is not required. The images should link to <LinkTo @route="index">https://emberjs.com/</LinkTo>.</p>
+  </section>
+
+  <section aria-labelledby="blog-posts-and-articles" class="branding-section">
+    <h2 id="blog-post-and-articles">Blog Posts and Articles</h2>
+    <p>Blogs by individuals, companies, and media publications may utilize any of the pieces of art below in the <a href="#standard-art-set">Standard Art Set section</a>, provided they add the following footer content to their posts/pages:</p>
+    <p>
+      <em>Ember, the Ember logo, and the Tomster/Zoey designs are exclusive trademarks registered in the United States by Tilde Inc, and are used here with permission. [Blog page/product/etc] is unaffiliated with the Ember project, and the use of this art does not imply any endorsement or official status.</em>
+    </p>
+    <p>We reserve the right to require the art to be taken down at any point, with or without explanation.</p>
+  </section>
+
+  <section aria-labelledby="presentation-slides" class="branding-section">
+    <h2 id="presentation-slides">Presentation Slides</h2>
+    <p>The <a href="#standard-art-set">Standard Art Set</a> may also be used in presentation slides for industry conferences, internal corporate presentations, training presentations, and funding pitch decks, provided the following footer/asterisk content is added to a slide earlier in the Deck than where the art is used (it's alright for it to be small). It needs to appear once per deck, not every time a piece of art is used:</p>
+    <p>
+      <em>Ember, the Ember logo, and the Tomster/Zoey designs are exclusive trademarks registered in the United States by Tilde Inc, and are used here with permission. [Blog page/product/etc] is unaffiliated with the Ember project, and the use of this art does not imply any endorsement or official status.</em>
+    </p>
+  </section>
+
+  <section aria-labelledby="standard-art-set" class="branding-section">
+    <h2 id="standard-art-set">Standard Art Set</h2>
+    <p>The following items are included in the Standard Art Set:</p>
+    <p>
+      <em>Tomster/Zoey Octane car lockup, Primary Logo Lockup,
+        <a href="/mascots/#ember-a11y" rel="noopener noreferrer" target="_blank">Ember A11y Tomster and Zoey</a>,
+        <a href="/mascots/#classic-zoey" rel="noopener noreferrer" target="_blank">Classic Zoey</a>,
+        <a href="/mascots/#lt-s-tomster" rel="noopener noreferrer" target="_blank">LTS Tomster</a>,
+        <a href="/mascots/#construction-tomster" rel="noopener noreferrer" target="_blank">Construction Tomster</a>,
+        <a href="/mascots/#classic-tomster" rel="noopener noreferrer" target="_blank">Classic Tomster</a>,
+        <a href="/mascots/#original-tomster" rel="noopener noreferrer" target="_blank">Original Tomster</a>, 
+      </em>
+    </p>
+  </section>
+
   <section aria-labelledby="project-naming" class="branding-section">
     <h2 id="project-naming">Naming</h2>
     <p>Please avoid naming your projects and events anything that implies Ember or Tilde's endorsement. Keep this in mind when selecting domain names as well.</p>


### PR DESCRIPTION
This MR works on the Copy/Content Updates to /logos/ page #1007 issue tasks:

1. Each section has an ID that can be used in the anchor link in order to navigate to a specific section
2. Added id to each Mascot ListItem li i.e `mascot.id`
3. Added the necessary sections
4. Added links to each instance of the Standard Art Set
5. Added the links to the mascot items specified in Standard Art Set