### PR TITLE
New page: Community Resources

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -20,6 +20,7 @@ Router.map(function () {
     });
     this.route('meetups-getting-started');
     this.route('invasion-of-ukraine');
+    this.route('resources');
   });
 
   this.route('editions', function () {

--- a/app/templates/community/resources.hbs
+++ b/app/templates/community/resources.hbs
@@ -1,0 +1,57 @@
+{{page-title 'Resources'}}
+<section class='container' aria-labelledby='community-resources'>
+  <h1 id='community-resources'>
+    Community Resources
+  </h1>
+
+  <p>
+    Community members have provided useful projects that may help others learn,
+    share ideas, and demonstrate technical possibilities.
+  </p>
+
+  <div class='lg:col-4'>
+    <h2>Tutorials</h2>
+    <p>
+      <a href='https://tutorial.glimdown.com'>The Glimmer Tutorial</a>
+      is an interactive tutorial for Polaris' new fileformat: gjs. By
+      <a href='https://github.com/nullvoxpopuli'>@NullVoxPopuli</a>
+    </p>
+    <p>
+      <a href='https://limber.glimdown.com'>Limber</a>
+      is a fast REPL for quickly prototyping out ideas or issue reproductions in
+      Ember. By
+      <a href='https://github.com/nullvoxpopuli'>@NullVoxPopuli</a>
+    </p>
+  </div>
+
+  <div class='lg:col-4'>
+    <h2>Sample Apps</h2>
+    <p>
+      <a href='http://discuss.emberjs.com'>Ember Discussion Forum</a>
+      &mdash; a great venue for discussing features, architecture and best
+      practices.
+    </p>
+  </div>
+
+  <div class='lg:col-4'>
+    <h2>Technical Demos</h2>
+    <p>
+      <a href='https://github.com/lifeart/demo-ember-vite'>Using Vite with Ember</a>
+      &mdash; This is the hard way to use Vite with Ember, but it showcases what
+      modern build tooling can achieve, and represents (at a high level) the
+      end-goal of the
+      <a
+        href='https://github.com/embroider-build/embroider/issues'
+      >Embroider</a>
+      efforts -- where build times are instant -- though under embroider, there
+      will be much less boilerplate. By
+      <a href='https://github.com/lifeart'>@lifeart</a>
+    </p>
+  </div>
+
+  <p>
+    Disclaimer: these links may contain out of date information, and may or may
+    not align with ember's plans, past, present, or future.
+  </p>
+
+</section>

--- a/app/utils/header-links.js
+++ b/app/utils/header-links.js
@@ -102,6 +102,11 @@ export default [
         type: 'link',
       },
       {
+        href: 'https://emberjs.com/community/resources',
+        name: 'Community Resources',
+        type: 'link',
+      },
+      {
         href: 'https://emberjs.com/community/black-lives-matter/',
         name: 'Black Lives Matter',
         type: 'link',


### PR DESCRIPTION
Just a prototype, I remembered that I need to do something, so I'll come back to this eventually

This comes out of a long history of the community wanting stuff newer then what the guides offer (Pinned to an Edition, not changing until the next Edition (which is good, because it's a cohesive story that needs telling for each edition)) -- but there is another type of content, which doesn't fit the cookbook style docs either -- links.

Discord conversation here: https://discord.com/channels/480462759797063690/1125702689586696282/1125766220818427914

There are way more links to add. I'll try to find everything I know of before taking the PR out of draft state.