### PR TITLE
New Link: "Try" (out the framework)

### DIFF
--- a/app/utils/header-links.js
+++ b/app/utils/header-links.js
@@ -1,5 +1,10 @@
 export default [
   {
+    name: 'Try',
+    type: 'link',
+    href: 'http://new.emberjs.com',
+  },
+  {
     name: 'Docs',
     type: 'dropdown',
     items: [


### PR DESCRIPTION
We can have people try out ember in their browsers before they do any setup on their machines.

Note, right now booting up broccoli in the browser is not the fastest experience.
But the work on embroider, getting to vite, and converting the core addons to the v2 addon format will cut that time down _immensely_