### PR TITLE
added target="_blank" in the anchor tag for the hyperlink

### DIFF
--- a/app/templates/logos.hbs
+++ b/app/templates/logos.hbs
@@ -3,7 +3,7 @@
   <section aria-labelledby="branding" class="branding-section">
     <h1 id="branding">Branding</h1>
     <p>The Ember brand and associated assets are part of a meticulously curated experience. We take great pride in what our team and community have helped bring to life, and ask that you follow our guidelines to ensure consistency across all Ember properties.</p>
-    <p><a href="/pdfs/Ember-Brand-Guidelines.pdf">Download brand guidelines (PDF)</a></p>
+    <p><a href="/pdfs/Ember-Brand-Guidelines.pdf" target="_blank">Download brand guidelines (PDF)</a></p>
   </section>
 
   <section aria-labelledby="logos" class="branding-section">


### PR DESCRIPTION
PR for issue #1051 

Now the hyperlink of 'Download brand guidelines (PDF)' will explicitly open in a new tab as the target attribute is set to "_blank" and will not give a 404 error.