### PR TITLE
Update browser-support.hbs to include v5

### DIFF
--- a/app/templates/browser-support.hbs
+++ b/app/templates/browser-support.hbs
@@ -3,6 +3,39 @@
   <section aria-labelledby="section-browser-support-policy">
     <h1 id="section-browser-support-policy">Ember.js Browser Support Policy</h1>
 
+    <h2>Ember 5.0.0</h2>
+
+    <p>
+      In Ember 5.0.0, the framework supports the following major browsers:
+    </p>
+
+    <ul class="list-unstyled layout my-3">
+      <EsCard class="lg:col-2">
+        <div class="text-center text-md">Desktop</div>
+        <ul>
+          <li>Google Chrome >= 103</li>
+          <li>Mozilla Firefox >= 102</li>
+          <li>Microsoft Edge >= 110</li>
+          <li>Safari >= 12</li>
+        </ul>
+      </EsCard>
+      <EsCard class="lg:col-2">
+        <div class="text-center text-md">Mobile</div>
+        <ul>
+          <li>Google Chrome >= 112</li>
+          <li>Mozilla Firefox >= 110</li>
+          <li>Safari >= 12</li>
+        </ul>
+      </EsCard>
+      <EsCard class="lg:col-2">
+        <div class="text-center text-md">Testing</div>
+        <ul>
+          <li>Google Chrome</li>
+          <li>Mozilla Firefox</li>
+        </ul>
+      </EsCard>
+    </ul>
+
     <h2>Ember 4.0.0</h2>
 
     <p>


### PR DESCRIPTION
https://emberjs.com/browser-support/ states v3 in present tense and talks about v4 in future tense, which is outdated.

Also v5 has been released some time ago but page does not mention it.