### PR TITLE
Add non supported bugfix and security patch until dates

### DIFF
--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -83,6 +83,8 @@
       <th>LTS version</th>
       <th>Last minor release</th>
       <th>Last minor release date</th>
+      <th>Bugfixes until</th>
+      <th>Security patches until</th>
     </tr>
   </thead>
   <tbody>
@@ -90,71 +92,99 @@
       <td>4.8</td>
       <td>4.8.6</td>
       <td>June 2023</td>
+      <td>August 2023</td>
+      <td>December 2023</td>
     </tr>
     <tr>
       <td>4.4</td>
       <td>4.4.5</td>
       <td>May 2023</td>
+      <td>March 2023</td>
+      <td>July 2023</td>
     </tr>
     <tr>
       <td>3.28</td>
       <td>3.28.12</td>
       <td>May 2023</td>
+      <td>August 2022</td>
+      <td>January 2023</td>
     </tr>
     <tr>
       <td>3.24</td>
       <td>3.24.7</td>
       <td>November 2022</td>
+      <td>November 2021</td>
+      <td>March 2022</td>
     </tr>
     <tr>
       <td>3.20</td>
       <td>3.20.6</td>
       <td>November 2020</td>
+      <td>May 2021</td>
+      <td>September 2021</td>
     </tr>
     <tr>
       <td>3.16</td>
       <td>3.16.10</td>
       <td>August 2020</td>
+      <td>November 2020</td>
+      <td>March 2021</td>
     </tr>
     <tr>
       <td>3.12</td>
       <td>3.12.4</td>
       <td>May 2020</td>
+      <td>June 2020</td>
+      <td>October 2020</td>
     </tr>
     <tr>
       <td>3.8</td>
       <td>3.8.3</td>
       <td>June 2019</td>
+      <td>December 2019</td>
+      <td>April 2020</td>
     </tr>
     <tr>
       <td>3.4</td>
       <td>3.4.8</td>
       <td>January 2019</td>
+      <td>June 2019</td>
+      <td>October 2019</td>
     </tr>
     <tr>
       <td>2.18</td>
       <td>2.18.2</td>
       <td>February 2018</td>
+      <td>October 2018</td>
+      <td>February 2019</td>
     </tr>
     <tr>
       <td>2.16</td>
       <td>2.16.4</td>
       <td>February 2018</td>
+      <td>July 2018</td>
+      <td>December 2018</td>
     </tr>
     <tr>
       <td>2.12</td>
       <td>2.12.2</td>
       <td>April 2017</td>
+      <td>January 2018</td>
+      <td>May 2018</td>
     </tr>
     <tr>
       <td>2.8</td>
       <td>2.8.3</td>
       <td>November 2016</td>
+      <td>June 2017</td>
+      <td>October 2017</td>
     </tr>
     <tr>
       <td>2.4</td>
       <td>2.4.5</td>
       <td>April 2016</td>
+      <td>December 2016</td>
+      <td>April 2017</td>
     </tr>
   </tbody>
 </table>

--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -98,8 +98,8 @@
     </tr>
     <tr>
       <td>3.28</td>
-      <td>3.28.11</td>
-      <td>November 2022</td>
+      <td>3.28.12</td>
+      <td>May 2023</td>
     </tr>
     <tr>
       <td>3.24</td>

--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -103,8 +103,8 @@
     </tr>
     <tr>
       <td>3.24</td>
-      <td>3.24.6</td>
-      <td>November 2021</td>
+      <td>3.24.7</td>
+      <td>November 2022</td>
     </tr>
     <tr>
       <td>3.20</td>

--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -82,7 +82,7 @@
     <tr>
       <th>LTS version</th>
       <th>Last minor release</th>
-      <th>Last minor release date</th>
+      <th>LTS promotion</th>
       <th>Bugfixes until</th>
       <th>Security patches until</th>
     </tr>
@@ -91,100 +91,100 @@
     <tr>
       <td>4.8</td>
       <td>4.8.6</td>
-      <td>June 2023</td>
-      <td>August 2023</td>
-      <td>December 2023</td>
+      <td>December 8, 2022</td>
+      <td>July 6, 2023</td>
+      <td>December 21, 2023</td>
     </tr>
     <tr>
       <td>4.4</td>
       <td>4.4.5</td>
-      <td>May 2023</td>
-      <td>March 2023</td>
-      <td>July 2023</td>
+      <td>July 13, 2022</td>
+      <td>February 8, 2023</td>
+      <td>July 26, 2023</td>
     </tr>
     <tr>
       <td>3.28</td>
       <td>3.28.12</td>
-      <td>May 2023</td>
-      <td>August 2022</td>
-      <td>January 2023</td>
+      <td>December 20, 2021</td>
+      <td>July 18, 2022</td>
+      <td>January 2, 2023</td>
     </tr>
     <tr>
       <td>3.24</td>
       <td>3.24.7</td>
-      <td>November 2022</td>
-      <td>November 2021</td>
-      <td>March 2022</td>
+      <td>February 25, 2021</td>
+      <td>September 23, 2021</td>
+      <td>March 10, 2022</td>
     </tr>
     <tr>
       <td>3.20</td>
       <td>3.20.6</td>
-      <td>November 2020</td>
-      <td>May 2021</td>
-      <td>September 2021</td>
+      <td>September 2, 2020</td>
+      <td>March 31, 2021</td>
+      <td>September 15, 2021</td>
     </tr>
     <tr>
       <td>3.16</td>
       <td>3.16.10</td>
-      <td>August 2020</td>
-      <td>November 2020</td>
-      <td>March 2021</td>
+      <td>March 16, 2020</td>
+      <td>October 12, 2020</td>
+      <td>March 29, 2021</td>
     </tr>
     <tr>
       <td>3.12</td>
       <td>3.12.4</td>
-      <td>May 2020</td>
-      <td>June 2020</td>
-      <td>October 2020</td>
+      <td>September 25, 2019</td>
+      <td>April 22, 2020</td>
+      <td>October 7, 2020</td>
     </tr>
     <tr>
       <td>3.8</td>
       <td>3.8.3</td>
-      <td>June 2019</td>
-      <td>December 2019</td>
-      <td>April 2020</td>
+      <td>April 10, 2019</td>
+      <td>November 6, 2019</td>
+      <td>April 22, 2020</td>
     </tr>
     <tr>
       <td>3.4</td>
       <td>3.4.8</td>
-      <td>January 2019</td>
-      <td>June 2019</td>
-      <td>October 2019</td>
+      <td>October 15, 2018</td>
+      <td>May 13, 2019</td>
+      <td>October 28, 2019</td>
     </tr>
     <tr>
       <td>2.18</td>
       <td>2.18.2</td>
-      <td>February 2018</td>
-      <td>October 2018</td>
-      <td>February 2019</td>
+      <td>February 14, 2018</td>
+      <td>September 12, 2018</td>
+      <td>February 27, 2019</td>
     </tr>
     <tr>
       <td>2.16</td>
       <td>2.16.4</td>
-      <td>February 2018</td>
-      <td>July 2018</td>
-      <td>December 2018</td>
+      <td>November 20, 2017</td>
+      <td>June 18, 2018</td>
+      <td>December 3, 2018</td>
     </tr>
     <tr>
       <td>2.12</td>
       <td>2.12.2</td>
-      <td>April 2017</td>
-      <td>January 2018</td>
-      <td>May 2018</td>
+      <td>April 29, 2017</td>
+      <td>November 25, 2017</td>
+      <td>May 12, 2018</td>
     </tr>
     <tr>
       <td>2.8</td>
       <td>2.8.3</td>
-      <td>November 2016</td>
-      <td>June 2017</td>
-      <td>October 2017</td>
+      <td>October 17, 2016</td>
+      <td>May 15, 2017</td>
+      <td>October 30, 2017</td>
     </tr>
     <tr>
       <td>2.4</td>
       <td>2.4.5</td>
-      <td>April 2016</td>
-      <td>December 2016</td>
-      <td>April 2017</td>
+      <td>April 11, 2016</td>
+      <td>November 7, 2016</td>
+      <td>April 24, 2017</td>
     </tr>
   </tbody>
 </table>

--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -108,8 +108,8 @@
     </tr>
     <tr>
       <td>3.20</td>
-      <td>3.20.3</td>
-      <td>August 2020</td>
+      <td>3.20.6</td>
+      <td>November 2020</td>
     </tr>
     <tr>
       <td>3.16</td>


### PR DESCRIPTION
Per [this message](https://discord.com/channels/480462759797063690/1131610462207873025/1164957530112409670) in the ember-js discord, let's add a couple of new columns (Bugfixes until and Security patches until) to the no longer maintained LTS table on the `releases/lts` route.

While glossing over this, I _think_ that I caught a few instances where we were showing the incorrect minor version / date for a few LTS versions as well, but definitely worth double checking them.