### PR TITLE
Correct number of weeks added to promotion date

### DIFF
--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -65,7 +65,7 @@
         <tr>
           <td>{{release.version}}</td>
           <td>{{format-date-time release.promotionDate "MMMM D, YYYY"}}</td>
-          <td>{{format-date-time (add-weeks release.promotionDate 36) "MMMM D, YYYY"}}</td>
+          <td>{{format-date-time (add-weeks release.promotionDate 30) "MMMM D, YYYY"}}</td>
           <td>{{format-date-time (add-weeks release.promotionDate 54) "MMMM D, YYYY"}}</td>
         </tr>
       {{/each}}


### PR DESCRIPTION
It would be 36 added to the release date, but only 30 from promotion date