### PR TITLE
releases/lts: drop last minor version column

### DIFF
--- a/app/templates/releases/lts.hbs
+++ b/app/templates/releases/lts.hbs
@@ -42,6 +42,10 @@
   Before a version can be called an "LTS" release, it has to spend at least 6 weeks as a stable release, where it is used and tested by thousands of developers.
 </p>
 
+<p>
+  A complete release history for Ember is available <a href="https://github.com/emberjs/ember.js/releases" target="_blank" rel="noopener noreferrer">on GitHub</a>.
+</p>
+
 
 <h2>LTS schedule</h2>
 
@@ -81,7 +85,6 @@
   <thead>
     <tr>
       <th>LTS version</th>
-      <th>Last minor release</th>
       <th>LTS promotion</th>
       <th>Bugfixes until</th>
       <th>Security patches until</th>
@@ -90,98 +93,84 @@
   <tbody>
     <tr>
       <td>4.8</td>
-      <td>4.8.6</td>
       <td>December 8, 2022</td>
       <td>July 6, 2023</td>
       <td>December 21, 2023</td>
     </tr>
     <tr>
       <td>4.4</td>
-      <td>4.4.5</td>
       <td>July 13, 2022</td>
       <td>February 8, 2023</td>
       <td>July 26, 2023</td>
     </tr>
     <tr>
       <td>3.28</td>
-      <td>3.28.12</td>
       <td>December 20, 2021</td>
       <td>July 18, 2022</td>
       <td>January 2, 2023</td>
     </tr>
     <tr>
       <td>3.24</td>
-      <td>3.24.7</td>
       <td>February 25, 2021</td>
       <td>September 23, 2021</td>
       <td>March 10, 2022</td>
     </tr>
     <tr>
       <td>3.20</td>
-      <td>3.20.6</td>
       <td>September 2, 2020</td>
       <td>March 31, 2021</td>
       <td>September 15, 2021</td>
     </tr>
     <tr>
       <td>3.16</td>
-      <td>3.16.10</td>
       <td>March 16, 2020</td>
       <td>October 12, 2020</td>
       <td>March 29, 2021</td>
     </tr>
     <tr>
       <td>3.12</td>
-      <td>3.12.4</td>
       <td>September 25, 2019</td>
       <td>April 22, 2020</td>
       <td>October 7, 2020</td>
     </tr>
     <tr>
       <td>3.8</td>
-      <td>3.8.3</td>
       <td>April 10, 2019</td>
       <td>November 6, 2019</td>
       <td>April 22, 2020</td>
     </tr>
     <tr>
       <td>3.4</td>
-      <td>3.4.8</td>
       <td>October 15, 2018</td>
       <td>May 13, 2019</td>
       <td>October 28, 2019</td>
     </tr>
     <tr>
       <td>2.18</td>
-      <td>2.18.2</td>
       <td>February 14, 2018</td>
       <td>September 12, 2018</td>
       <td>February 27, 2019</td>
     </tr>
     <tr>
       <td>2.16</td>
-      <td>2.16.4</td>
       <td>November 20, 2017</td>
       <td>June 18, 2018</td>
       <td>December 3, 2018</td>
     </tr>
     <tr>
       <td>2.12</td>
-      <td>2.12.2</td>
       <td>April 29, 2017</td>
       <td>November 25, 2017</td>
       <td>May 12, 2018</td>
     </tr>
     <tr>
       <td>2.8</td>
-      <td>2.8.3</td>
       <td>October 17, 2016</td>
       <td>May 15, 2017</td>
       <td>October 30, 2017</td>
     </tr>
     <tr>
       <td>2.4</td>
-      <td>2.4.5</td>
       <td>April 11, 2016</td>
       <td>November 7, 2016</td>
       <td>April 24, 2017</td>


### PR DESCRIPTION
Per https://github.com/ember-learn/ember-website/pull/1083#issuecomment-1939708692, the last minor version column is a little bit prone to having stale data. Instead, let's just provide a link to a place where the reader can find all of the releases of Ember.
