### PR TITLE
combo of npm + ignore-scripts=true means the app can't start -- solution, which is a no-op for folks who don't change this setting, is to undisable scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=false


### PR DESCRIPTION
via the local `.npmrc` file