### PR TITLE
rely on the github config for the PERCY_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
         env:
           PERCY_PARALLEL_NONCE: ${{ env.PERCY_PARALLEL_NONCE }}
           PERCY_PARALLEL_TOTAL: ${{ env.PERCY_PARALLEL_TOTAL }}
-          PERCY_TOKEN: c08aaada222e9cb103a28b98e94d71ff8baaddb5a548237432d900f1d4a9ec27
 
   lighthouse-ci:
     name: Run Lighthouse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
         env:
           PERCY_PARALLEL_NONCE: ${{ env.PERCY_PARALLEL_NONCE }}
           PERCY_PARALLEL_TOTAL: ${{ env.PERCY_PARALLEL_TOTAL }}
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
   lighthouse-ci:
     name: Run Lighthouse


### PR DESCRIPTION
This is unfortunate because now it means that we can't have percy snapshots from forks 😞 