### PR TITLE
add the ability to link to a team on teams page

### DIFF
--- a/app/components/teams/team.hbs
+++ b/app/components/teams/team.hbs
@@ -1,6 +1,7 @@
 <h2
   class="text-center"
   data-test-field="Team Name"
+  id={{dasherize @name}}
 >
   {{@name}}
 </h2>

--- a/app/helpers/dasherize.js
+++ b/app/helpers/dasherize.js
@@ -1,0 +1,6 @@
+import { helper } from '@ember/component/helper';
+import { dasherize as dasherizeString } from '@ember/string';
+
+export default helper(function dasherize(positional /*, named*/) {
+  return dasherizeString(positional[0]);
+});

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^4.0.1",
     "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@ember/optional-features':
         specifier: ^2.0.0
         version: 2.2.0
+      '@ember/string':
+        specifier: ^4.0.1
+        version: 4.0.1
       '@ember/test-helpers':
         specifier: ^2.6.0
         version: 2.9.4(@babel/core@7.26.9)(ember-source@3.28.12(@babel/core@7.26.9))
@@ -903,6 +906,9 @@ packages:
   '@ember/string@3.1.1':
     resolution: {integrity: sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==}
     engines: {node: 12.* || 14.* || >= 16}
+
+  '@ember/string@4.0.1':
+    resolution: {integrity: sha512-VWeng8BSWrIsdPfffOQt/bKwNKJL7+37gPFh/6iZZ9bke+S83kKqkS30poo4bTGfRcMnvAE0ie7txom+iDu81Q==}
 
   '@ember/test-helpers@2.9.4':
     resolution: {integrity: sha512-z+Qs1NYWyIVDmrY6WdmOS5mdG1lJ5CFfzh6dRhLfs9lq45deDaDrVNcaCYhnNeJZTvUBK2XR2SvPcZm0RloXdA==}
@@ -9845,6 +9851,8 @@ snapshots:
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - supports-color
+
+  '@ember/string@4.0.1': {}
 
   '@ember/test-helpers@2.9.4(@babel/core@7.26.9)(ember-source@3.28.12(@babel/core@7.26.9))':
     dependencies:

--- a/tests/integration/helpers/dasherize-test.js
+++ b/tests/integration/helpers/dasherize-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | dasherize', function (hooks) {
+  setupRenderingTest(hooks);
+
+  /**
+   * This doesn't need comprehensive tests for the output of the dasherzie function
+   * since it's just using @ember/string under the hood. This is just a smoke test
+   * to make sure it's hooked up correctly
+   */
+  test('it renders', async function (assert) {
+    this.set('inputValue', 'Something Awesome');
+
+    await render(hbs`{{dasherize this.inputValue}}`);
+
+    assert.dom(this.element).hasText('something-awesome');
+  });
+});


### PR DESCRIPTION
This doesn't add any visual indication on how to link to a team but it just allows you to manually link 👍 

Here is an example with the preview deploy https://deploy-preview-1140--ember-website.netlify.app/teams/#the-ember-tooling-core-team