### PR TITLE
update the anchor for the ember initiative

### DIFF
--- a/app/templates/sponsors.hbs
+++ b/app/templates/sponsors.hbs
@@ -36,8 +36,8 @@
     </ul>
   </section>
 
-  <section class="my-5" aria-labelledby="ember-sponsors-and-friends-embroider-initiative">
-    <h2 id="ember-sponsors-and-friends-embroider-initiative">Ember Initiative Sponsors</h2>
+  <section class="my-5" aria-labelledby="ember-sponsors-and-friends-ember-initiative">
+    <h2 id="ember-sponsors-and-friends-ember-initiative">Ember Initiative Sponsors</h2>
 
     <ul class="unstyled grid sm:grid-2 lg:grid-3">
       {{#each


### PR DESCRIPTION
This just makes it so that you can go to https://emberjs.com/sponsors/#ember-sponsors-and-friends-ember-initiative instead of https://emberjs.com/sponsors/#ember-sponsors-and-friends-embroider-initiative