### PR TITLE
Correct browser versions for 6.x

### DIFF
--- a/app/templates/browser-support.hbs
+++ b/app/templates/browser-support.hbs
@@ -65,17 +65,17 @@
       <EsCard class="lg:col-2">
         <div class="text-center text-md">Desktop</div>
         <ul>
-          <li>Google Chrome >= 103</li>
+          <li>Google Chrome >= 109</li>
           <li>Mozilla Firefox >= 115</li>
-          <li>Microsoft Edge >= 122</li>
-          <li>Safari >= 16.6</li>
+          <li>Microsoft Edge >= 128</li>
+          <li>Safari >= 15.6</li>
         </ul>
       </EsCard>
       <EsCard class="lg:col-2">
         <div class="text-center text-md">Mobile</div>
         <ul>
-          <li>Google Chrome >= 124</li>
-          <li>Mozilla Firefox >= 125</li>
+          <li>Google Chrome >= 109</li>
+          <li>Mozilla Firefox >= 115</li>
           <li>Safari >= 15.6</li>
         </ul>
       </EsCard>


### PR DESCRIPTION
This was incorrect ... versions are available via require('ember-source').supportedBrowser and can be seen here https://github.com/emberjs/ember.js/blob/main/lib/browsers.js