### PR TITLE
More calls to action

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -57,3 +57,9 @@ h1 + *,
 button:not([disabled]) {
   cursor: pointer;
 }
+
+.cta-group {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -5,10 +5,12 @@
     <div class="lg:col-5">
       <h1 class="text-hero-xl" id="hero-title">A framework for ambitious <br class="hide-on-mobile">web developers.</h1>
       <p class="text-hero-base mb-2">Ember.js is a productive, battle-tested JavaScript framework for building modern web applications. It includes everything you need to build rich UIs that work on any device.</p>
-      <a href="https://guides.emberjs.com/release/tutorial/" class="es-button" title="New to building websites, or just want a more in-depth introduction to Ember? The tutorial is for you!">Read the Tutorial</a>
-      <a href="https://guides.emberjs.com/release/getting-started/quick-start/" class="es-button-secondary" title="Get started with the framework, a quick reference to setting up new projects">Get started
-      </a>
-      <a href="https://api.emberjs.com/" class="es-button-secondary" title="View the API reference">API Reference</a>
+      <div class="cta-group">
+        <a href="https://guides.emberjs.com/release/tutorial/" class="es-button" title="New to building websites, or just want a more in-depth introduction to Ember? The tutorial is for you!">Read the Tutorial</a>
+        <a href="https://guides.emberjs.com/release/getting-started/quick-start/" class="es-button-secondary" title="Get started with the framework, a quick reference to setting up new projects">Get started
+        </a>
+        <a href="https://api.emberjs.com/" class="es-button-secondary" title="View the API reference">API Reference</a>
+      </div>
 
 
     </div>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -6,6 +6,11 @@
       <h1 class="text-hero-xl" id="hero-title">A framework for ambitious <br class="hide-on-mobile">web developers.</h1>
       <p class="text-hero-base mb-2">Ember.js is a productive, battle-tested JavaScript framework for building modern web applications. It includes everything you need to build rich UIs that work on any device.</p>
       <a href="https://guides.emberjs.com/release/tutorial/" class="es-button" title="New to building websites, or just want a more in-depth introduction to Ember? The tutorial is for you!">Read the Tutorial</a>
+      <a href="https://guides.emberjs.com/release/getting-started/quick-start/" class="es-button-secondary" title="Get started with the framework, a quick reference to setting up new projects">Get started
+      </a>
+      <a href="https://api.emberjs.com/" class="es-button-secondary" title="View the API reference">API Reference</a>
+
+
     </div>
   </div>
   <CommunityTrends />

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -6,10 +6,8 @@
       <h1 class="text-hero-xl" id="hero-title">A framework for ambitious <br class="hide-on-mobile">web developers.</h1>
       <p class="text-hero-base mb-2">Ember.js is a productive, battle-tested JavaScript framework for building modern web applications. It includes everything you need to build rich UIs that work on any device.</p>
       <div class="cta-group">
-        <a href="https://guides.emberjs.com/release/tutorial/" class="es-button" title="New to building websites, or just want a more in-depth introduction to Ember? The tutorial is for you!">Read the Tutorial</a>
-        <a href="https://guides.emberjs.com/release/getting-started/quick-start/" class="es-button-secondary" title="Get started with the framework, a quick reference to setting up new projects">Get started
-        </a>
-        <a href="https://api.emberjs.com/" class="es-button-secondary" title="View the API reference">API Reference</a>
+        <a href="https://guides.emberjs.com/release/getting-started/quick-start/" class="es-button" title="Get started with the framework, a quick reference to setting up new projects">Get started</a>
+        <a href="https://guides.emberjs.com/release/tutorial/" class="es-button-secondary" title="New to building websites, or just want a more in-depth introduction to Ember? The tutorial is for you!">Read the full tutorial</a>
       </div>
 
 


### PR DESCRIPTION
There hasn't anything for folks who are "somewhat familiar" with the framework.

This PR adds two new calls-to-action which link to existing pages:
- the quickstart -- for folks who don't want to read the tutorial (like if they've already read it), and they want to see how to make a new app, or refresh their memory on what the specific commands are
- the API reference -- for folks who are already using ember, and want to look something up.

## Micro Screens
<img width="529" height="897" alt="image" src="https://github.com/user-attachments/assets/40da104d-5b6c-40e2-8c60-0e21474099a8" />



## Small Screens
<img width="1088" height="588" alt="image" src="https://github.com/user-attachments/assets/c6da0b10-845e-4100-a352-223a35c9ec35" />


## Larger Screens
<img width="1715" height="826" alt="image" src="https://github.com/user-attachments/assets/e2acf91d-8a5a-4e44-b6f4-b7d416211ecf" />


