### PR TITLE
Move Peter Wagenet to alumni

### DIFF
--- a/data/team-member/peter-wagenet.md
+++ b/data/team-member/peter-wagenet.md
@@ -6,6 +6,5 @@ github: 'https://github.com/wagenet'
 image: pwagenet.jpg
 added: 2013-04-02T09:02:00.000Z
 teams:
-  - corejs
-  - tooling
+  - alumni
 ---

--- a/tests/unit/controllers/teams/emeritus-test.js
+++ b/tests/unit/controllers/teams/emeritus-test.js
@@ -21,6 +21,7 @@ module('Unit | Controller | teams/emeritus', function (hooks) {
     const output = alumniTeamMembers.map((teamMember) => teamMember.id);
 
     assert.deepEqual(output, [
+      'peter-wagenet',
       'trek-glowacki',
       'erik-bryn',
       'kris-selden',

--- a/tests/unit/controllers/teams/index-test.js
+++ b/tests/unit/controllers/teams/index-test.js
@@ -39,7 +39,6 @@ module('Unit | Controller | teams/index', function (hooks) {
     assert.deepEqual(output, [
       'yehuda-katz',
       'tom-dale',
-      'peter-wagenet',
       'leah-silber',
       'matthew-beale',
       'edward-faulkner',
@@ -56,7 +55,6 @@ module('Unit | Controller | teams/index', function (hooks) {
     const output = coreToolingTeamMembers.map((teamMember) => teamMember.id);
 
     assert.deepEqual(output, [
-      'peter-wagenet',
       'edward-faulkner',
       'katie-gengler',
       'kelly-selden',


### PR DESCRIPTION
Moves Peter Wagenet from corejs and tooling teams to alumni.

Now that @NullVoxPopuli is on the Core Team, I feel like Optro (formerly AuditBoard) is well represented now. I still love Ember, but just haven't had all the much time to work on it in my current role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)