### PR TITLE
Add Jobs in JS to community resources

### DIFF
--- a/app/templates/community/index.hbs
+++ b/app/templates/community/index.hbs
@@ -25,6 +25,9 @@
       <a href="https://emberwork.com/">EMBERWORK</a> &mdash; find your next Ember job opportunity on this dedicated platform for Ember jobs, curated by community members.
     </p>
     <p>
+      <a href="https://jobsinjs.com/ember-js-developer-jobs/">Jobs in JS</a> &mdash; a JavaScript job board with a dedicated Ember.js section, updated daily from company hiring feeds.
+    </p>
+    <p>
       Please note that these resources are not managed or moderated by the Ember Core Team. They are public forums.
     </p>
   </div>


### PR DESCRIPTION
Adds [jobsinjs.com/ember-js-developer-jobs](https://jobsinjs.com/ember-js-developer-jobs/) to the community resources list, alongside EMBERWORK.

It's a Javascript-focused job board with a dedicated Ember.js section. Honestly, it's not as Ember-focused as EMBERWORK, but the latter doesn't seem to be very active, so thought this might be a good complementary fit.

Free for job seekers, no account or login required.